### PR TITLE
compilation error fixes when packet_rgb mode enabled

### DIFF
--- a/include/mitsuba/core/spline.h
+++ b/include/mitsuba/core/spline.h
@@ -1015,7 +1015,7 @@ Value eval_2d(const Float *nodes1, uint32_t size1, const Float *nodes2,
             index += 1;
         }
 
-        index += size1 - 4;
+        index += (int32_t) size1 - 4;
     }
 
     return result;

--- a/src/integrators/volpath-simple.cpp
+++ b/src/integrators/volpath-simple.cpp
@@ -63,7 +63,7 @@ public:
         UInt32 channel = 0;
         if (is_rgb_v<Spectrum>) {
             uint32_t n_channels = (uint32_t) array_size_v<Spectrum>;
-            channel = min(sampler->next_1d(active) * n_channels, n_channels - 1);
+            channel = (UInt32) min(sampler->next_1d(active) * n_channels, n_channels - 1);
         }
 
         SurfaceInteraction3f si;

--- a/src/integrators/volpath.cpp
+++ b/src/integrators/volpath.cpp
@@ -116,7 +116,7 @@ public:
         UInt32 channel = 0;
         if (is_rgb_v<Spectrum>) {
             uint32_t n_channels = (uint32_t) array_size_v<Spectrum>;
-            channel = min(sampler->next_1d(active) * n_channels, n_channels - 1);
+            channel = (UInt32) min(sampler->next_1d(active) * n_channels, n_channels - 1);
         }
 
         SurfaceInteraction3f si;


### PR DESCRIPTION
This patch is to resolve the following build errors faced while compiling on macos 10.15.3. Please review it.

mitsuba.conf
```sh
"enabled": [
    "scalar_rgb",
    "scalar_spectral",
    "packet_rgb"
],
...
```

Compiler:
```sh
Apple clang version 11.0.0 (clang-1100.0.33.17)
Target: x86_64-apple-darwin19.3.0
Thread model: posix
```

Build errors:
```sh
../ext/enoki/include/enoki/array_router.h:197:1: error: use of overloaded operator '=' is ambiguous (with oper
and types 'enoki::Packet<int, 8>' and 'enoki::Packet<unsigned int, 8>')                                       
ENOKI_ROUTE_COMPOUND_OPERATOR(+)                                                                              
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                              
../ext/enoki/include/enoki/array_router.h:156:12: note: expanded from macro 'ENOKI_ROUTE_COMPOUND_OPERATOR'   
        a1 = a1 op a2;                                                         \                              
        ~~ ^ ~~~~~~~~                                                                                         
../include/mitsuba/core/spline.h:1018:15: note: in instantiation of function template specialization 'enoki::o
perator+=<enoki::Packet<int, 8>, 0, unsigned int>' requested here                                             
        index += size1 - 4;                                                                                   
              ^                                                                                               
../src/libcore/python/spline_v.cpp:124:32: note: in instantiation of function template specialization 'mitsuba
::spline::eval_2d<false, enoki::Packet<float, 8>, float>' requested here                                      
                return spline::eval_2d(nodes1.data(), (uint32_t) nodes1.shape(0),
```

```sh
../src/integrators/volpath-simple.cpp:66:21: error: use of overloaded operator '=' is ambiguous (with operand 
types 'mitsuba::VolumetricNullSimplePathIntegrator<enoki::Packet<float, 8>, mitsuba::Color<enoki::Packet<float
, 8>, 3> >::UInt32' (aka 'enoki::Packet<unsigned int, 8>') and 'enoki::Packet<float, 8>')
            channel = min(sampler->next_1d(active) * n_channels, n_channels - 1);
```

```sh
../src/integrators/volpath.cpp:119:21: error: use of overloaded operator '=' is ambiguous (with operand types 
'mitsuba::VolumetricNullPathIntegratorImpl<enoki::Packet<float, 8>, mitsuba::Color<enoki::Packet<float, 8>, 3>
, true>::UInt32' (aka 'enoki::Packet<unsigned int, 8>') and 'enoki::Packet<float, 8>')
            channel = min(sampler->next_1d(active) * n_channels, n_channels - 1);
```

Thank you.