### PR TITLE
Bugfixes (XML multi-object expand(), environment map classification)

### DIFF
--- a/include/mitsuba/core/spectrum.h
+++ b/include/mitsuba/core/spectrum.h
@@ -344,8 +344,8 @@ inline void spectrum_from_file(const std::string &filename,
 }
 
 template <typename Scalar>
-inline Color<Scalar, 3> spectrum_to_rgb(std::vector<Scalar> &wavelengths,
-                                        std::vector<Scalar> &values,
+inline Color<Scalar, 3> spectrum_to_rgb(const std::vector<Scalar> &wavelengths,
+                                        const std::vector<Scalar> &values,
                                         bool bounded=true) {
     Color<Scalar, 3> color = 0.f;
 

--- a/include/mitsuba/render/emitter.h
+++ b/include/mitsuba/render/emitter.h
@@ -64,7 +64,7 @@ public:
 
     /// Is this an environment map light emitter?
     bool is_environment() const {
-        return has_flag(m_flags, EmitterFlags::Infinite);
+        return has_flag(m_flags, EmitterFlags::Infinite) && !has_flag(m_flags, EmitterFlags::Delta);
     }
 
     /// Flags for all components combined.

--- a/src/libcore/xml.cpp
+++ b/src/libcore/xml.cpp
@@ -1041,7 +1041,7 @@ static ref<Object> instantiate_node(XMLParseContext &ctx, const std::string &id)
                 } else {
                     int ctr = 0;
                     for (auto c : children)
-                        props.set_object(kv.first + "_" + std::to_string(ctr++), children[0], false);
+                        props.set_object(kv.first + "_" + std::to_string(ctr++), c, false);
                 }
             } catch (const std::exception &e) {
                 if (strstr(e.what(), "Error while loading") == nullptr)


### PR DESCRIPTION
Bugfix to XML multi-object expansion, environment map emitter classification, and a spectrum utility signature. 

These fixes are included in the 'Compatibility & Sunsky' pull request (https://github.com/mitsuba-renderer/mitsuba2/pull/85), but separated here, since they are topically unrelated, small, and in part significant.

Description of the environment map issue: Directional lights are also marked Infinite, therefore erroneously classified as environment emitter and conflicting with other environment maps.