### PR TITLE
Bugfixes / Mitsuba 1 Compatibility

### DIFF
--- a/include/mitsuba/core/spectrum.h
+++ b/include/mitsuba/core/spectrum.h
@@ -344,8 +344,8 @@ inline void spectrum_from_file(const std::string &filename,
 }
 
 template <typename Scalar>
-inline Color<Scalar, 3> spectrum_to_rgb(std::vector<Scalar> &wavelengths,
-                                        std::vector<Scalar> &values,
+inline Color<Scalar, 3> spectrum_to_rgb(const std::vector<Scalar> &wavelengths,
+                                        const std::vector<Scalar> &values,
                                         bool bounded=true) {
     Color<Scalar, 3> color = 0.f;
 

--- a/include/mitsuba/render/emitter.h
+++ b/include/mitsuba/render/emitter.h
@@ -64,7 +64,7 @@ public:
 
     /// Is this an environment map light emitter?
     bool is_environment() const {
-        return has_flag(m_flags, EmitterFlags::Infinite);
+        return has_flag(m_flags, EmitterFlags::Infinite) && !has_flag(m_flags, EmitterFlags::Delta);
     }
 
     /// Flags for all components combined.

--- a/src/libcore/xml.cpp
+++ b/src/libcore/xml.cpp
@@ -1041,7 +1041,7 @@ static ref<Object> instantiate_node(XMLParseContext &ctx, const std::string &id)
                 } else {
                     int ctr = 0;
                     for (auto c : children)
-                        props.set_object(kv.first + "_" + std::to_string(ctr++), children[0], false);
+                        props.set_object(kv.first + "_" + std::to_string(ctr++), c, false);
                 }
             } catch (const std::exception &e) {
                 if (strstr(e.what(), "Error while loading") == nullptr)

--- a/src/libcore/xml.cpp
+++ b/src/libcore/xml.cpp
@@ -349,8 +349,11 @@ void upgrade_tree(XMLSource &src, pugi::xml_node &node, const Version &version) 
 
     if (version < Version(2, 0, 0)) {
         // Upgrade all attribute names from camelCase to underscore_case
-        for (pugi::xpath_node result: node.select_nodes("//@name")) {
-            pugi::xml_attribute name_attrib = result.attribute();
+        for (pugi::xpath_node result: node.select_nodes("//*[@name]")) {
+            pugi::xml_node n = result.node();
+            if (strcmp(n.name(), "default") == 0)
+                continue;
+            pugi::xml_attribute name_attrib = n.attribute("name");
             std::string name = name_attrib.value();
             for (size_t i = 0; i < name.length() - 1; ++i) {
                 if (std::islower(name[i]) && std::isupper(name[i + 1])) {
@@ -366,6 +369,21 @@ void upgrade_tree(XMLSource &src, pugi::xml_node &node, const Version &version) 
         }
         for (pugi::xpath_node result: node.select_nodes("//lookAt"))
             result.node().set_name("lookat");
+        // automatically rename reserved identifiers
+        for (pugi::xpath_node result: node.select_nodes("//@id")) {
+            pugi::xml_attribute id_attrib = result.attribute();
+            char const* val = id_attrib.value();
+            if (val && val[0] == '_') {
+                std::string new_id = std::string("ID") + val + "__UPGR";
+                Log(Warn, "Changing identifier: %s -> %s", val, new_id.c_str());
+                id_attrib = new_id.c_str();
+            }
+        }
+        // changed BSDFs
+        for (pugi::xpath_node result: node.select_nodes("//bsdf[@type='diffuse']/*/@name[.='diffuse_reflectance']")) {
+            Log(Warn, "diffuse::diffuseReflectance -> reflectance");
+            result.attribute() = "reflectance";
+        }
 
         // Update 'uoffset', 'voffset', 'uscale', 'vscale' to transform block
         for (pugi::xpath_node result : node.select_nodes(


### PR DESCRIPTION
This brings minor fixes for compatibility with previous scene file versions: It prevents the auto camelCase conversion from breaking <default> names, mangles names that collide with reserved IDs, and fixes 'diffuseReflectance' for diffuse BSDFs.

(Cannot split the commit tree right now, hope GitHub notices that part of it was already merged. Otherwise will have to repost with all changes split up later/tomorrow)