### PR TITLE
Spectrum: move two functions to .cpp

### DIFF
--- a/src/libcore/bitmap.cpp
+++ b/src/libcore/bitmap.cpp
@@ -1128,7 +1128,7 @@ void Bitmap::read_openexr(Stream *stream) {
                       BY = (Float) data[2];
 
                 if (std::is_integral<T>::value) {
-                    Float scale = Float(1) / std::numeric_limits<T>::max();
+                    Float scale = Float(1) / Float(std::numeric_limits<T>::max());
                     Y *= scale; RY *= scale; BY *= scale;
                 }
 
@@ -1137,7 +1137,7 @@ void Bitmap::read_openexr(Stream *stream) {
                       G = ((Y - R * yw.x - B * yw.z) / yw.y);
 
                 if (std::is_integral<T>::value) {
-                    Float scale = std::numeric_limits<T>::max();
+                    Float scale = Float(std::numeric_limits<T>::max());
                     R *= R * scale + .5f;
                     G *= G * scale + .5f;
                     B *= B * scale + .5f;
@@ -1200,7 +1200,7 @@ void Bitmap::read_openexr(Stream *stream) {
                       B = (Float) data[2];
 
                 if (std::is_integral<T>::value) {
-                    Float scale = Float(1) / std::numeric_limits<T>::max();
+                    Float scale = Float(1) / Float(std::numeric_limits<T>::max());
                     R *= scale; G *= scale; B *= scale;
                 }
 
@@ -1208,7 +1208,7 @@ void Bitmap::read_openexr(Stream *stream) {
                 R = Float(rgb[0]); G = Float(rgb[1]); B = Float(rgb[2]);
 
                 if (std::is_integral<T>::value) {
-                    Float scale = std::numeric_limits<T>::max();
+                    Float scale = Float(std::numeric_limits<T>::max());
                     R *= R * scale + 0.5f;
                     G *= G * scale + 0.5f;
                     B *= B * scale + 0.5f;


### PR DESCRIPTION
The goal is to reduce the size of `core/spectrum.h` (including the headers it includes) because it's used everywhere.

The two functions that were moved to `libcore/spectrum.cpp` were templated over `Scalar`, so they are explicitly instantiated for `float` and `double`.

Tested on Fedora 29 with modes "scalar_rgb", "scalar_spectral", "gpu_autodiff_rgb".

@Speierers, could you please check this doesn't break the Windows build?