### PR TITLE
minor fix for dielectric plugin documentation / homogeneous medium parametrization

### DIFF
--- a/src/bsdfs/dielectric.cpp
+++ b/src/bsdfs/dielectric.cpp
@@ -80,8 +80,8 @@ An example of how one might describe a slightly absorbing piece of glass is show
         </bsdf>
 
         <medium type="homogeneous" name="interior">
-            <rgb name="sigma_s" value="0, 0, 0"/>
-            <rgb name="sigma_a" value="4, 4, 2"/>
+            <rgb name="sigma_t" value="0, 0, 0"/>
+            <rgb name="albedo" value="0.156, 0.156, 0.008"/>
         </medium>
     <shape>
 

--- a/src/bsdfs/dielectric.cpp
+++ b/src/bsdfs/dielectric.cpp
@@ -80,8 +80,9 @@ An example of how one might describe a slightly absorbing piece of glass is show
         </bsdf>
 
         <medium type="homogeneous" name="interior">
-            <rgb name="sigma_t" value="0, 0, 0"/>
-            <rgb name="albedo" value="0.156, 0.156, 0.008"/>
+            <float name="density" value="4"/>
+	    <rgb name="sigma_t" value="1, 1, 0.5"/>
+	    <rgb name="albedo" value="0.0, 0.0, 0.0"/>
         </medium>
     <shape>
 


### PR DESCRIPTION
I changed the parameter names as well as the values as the following range is now expected in xml:
```
[xml.cpp:216]   [SRGBReflectanceSpectrum] Invalid RGB reflectance value [4, 4, 2], must be in the range [0, 1]!.
```
Please check if those values still describe a *slightly absorbing piece of glass* as -- as far as i understood -- _sigma_s_ is now computed from _sigma_t_ and _albedo_ in *src/media/homogeneous.cpp*.