### PR TITLE
Premultiplied alpha

### DIFF
--- a/include/mitsuba/core/bitmap.h
+++ b/include/mitsuba/core/bitmap.h
@@ -163,6 +163,20 @@ public:
     };
 
 
+
+    /// Type of alpha transformation
+    enum class AlphaTransform : uint32_t {
+        /// No transformation (default)
+        None,
+
+        // Premultiply channels by alpha
+        Premultiply,
+
+        // Unpremultiply (divide) channels by alpha
+        Unpremultiply
+    };
+
+
     // ======================================================================
     //! @{ \name Constructors
     // ======================================================================
@@ -277,6 +291,12 @@ public:
 
     /// Specify whether the bitmap uses an sRGB gamma encoding
     void set_srgb_gamma(bool value);
+
+    /// Return whether the bitmap uses premultiplied alpha
+    bool premultiplied_alpha() const { return m_premultiplied_alpha; }
+
+    /// Specify whether the bitmap uses premultiplied alpha
+    void set_premultiplied_alpha(bool value);
 
     /// Return a \ref Properties object containing the image metadata
     Properties &metadata() { return m_metadata; }
@@ -479,7 +499,8 @@ public:
      */
     ref<Bitmap> convert(PixelFormat pixel_format,
                         Struct::Type component_format,
-                        bool srgb_gamma = true) const;
+                        bool srgb_gamma,
+                        Bitmap::AlphaTransform alpha_transform = Bitmap::AlphaTransform::None) const;
 
     void convert(Bitmap *target) const;
 
@@ -617,6 +638,7 @@ public:
      Vector2u m_size;
      ref<Struct> m_struct;
      bool m_srgb_gamma;
+     bool m_premultiplied_alpha;
      bool m_owns_data;
      Properties m_metadata;
 };
@@ -695,5 +717,6 @@ void accumulate_2d(ConstT source,
 
 extern MTS_EXPORT_CORE std::ostream &operator<<(std::ostream &os, Bitmap::PixelFormat value);
 extern MTS_EXPORT_CORE std::ostream &operator<<(std::ostream &os, Bitmap::FileFormat value);
+extern MTS_EXPORT_CORE std::ostream &operator<<(std::ostream &os, Bitmap::AlphaTransform value);
 
 NAMESPACE_END(mitsuba)

--- a/include/mitsuba/core/struct.h
+++ b/include/mitsuba/core/struct.h
@@ -80,7 +80,17 @@ public:
          * expressed relative to its value. Converting to an un-weighted
          * structure entails a division by the weight.
          */
-        Weight     = 0x10
+        Weight     = 0x10,
+
+        /**
+         * Specifies whether the field encodes an alpha premultiplied value
+         */
+        PremultipliedAlpha      = 0x20,
+
+        /**
+         * Specifies whether the field encodes an alpha value
+        */
+        Alpha      = 0x40
     };
 
     /// Field specifier with size and offset

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -552,6 +552,14 @@ PNG and OpenEXR files are optionally annotated with string-valued
 metadata, and the gamma setting can be stored as well. Please see the
 class methods and enumerations for further detail.)doc";
 
+static const char *__doc_mitsuba_Bitmap_AlphaTransform = R"doc(Type of alpha transformation)doc";
+
+static const char *__doc_mitsuba_Bitmap_AlphaTransform_None = R"doc(No transformation (default))doc";
+
+static const char *__doc_mitsuba_Bitmap_AlphaTransform_Premultiply = R"doc(No transformation (default))doc";
+
+static const char *__doc_mitsuba_Bitmap_AlphaTransform_Unpremultiply = R"doc(No transformation (default))doc";
+
 static const char *__doc_mitsuba_Bitmap_Bitmap =
 R"doc(Create a bitmap of the specified type and allocate the necessary
 amount of memory
@@ -820,6 +828,8 @@ static const char *__doc_mitsuba_Bitmap_m_owns_data = R"doc()doc";
 
 static const char *__doc_mitsuba_Bitmap_m_pixel_format = R"doc()doc";
 
+static const char *__doc_mitsuba_Bitmap_m_premultiplied_alpha = R"doc()doc";
+
 static const char *__doc_mitsuba_Bitmap_m_size = R"doc()doc";
 
 static const char *__doc_mitsuba_Bitmap_m_srgb_gamma = R"doc()doc";
@@ -839,6 +849,8 @@ static const char *__doc_mitsuba_Bitmap_operator_ne = R"doc(Inequality compariso
 static const char *__doc_mitsuba_Bitmap_pixel_count = R"doc(Return the total number of pixels)doc";
 
 static const char *__doc_mitsuba_Bitmap_pixel_format = R"doc(Return the pixel format of this bitmap)doc";
+
+static const char *__doc_mitsuba_Bitmap_premultiplied_alpha = R"doc(Return whether the bitmap uses premultiplied alpha)doc";
 
 static const char *__doc_mitsuba_Bitmap_read = R"doc(Read a file from a stream)doc";
 
@@ -922,6 +934,8 @@ Parameter ``clamp``:
     Default: -infinity..infinity (i.e. no clamping is used))doc";
 
 static const char *__doc_mitsuba_Bitmap_set_metadata = R"doc(Set the a Properties object containing the image metadata)doc";
+
+static const char *__doc_mitsuba_Bitmap_set_premultiplied_alpha = R"doc(Specify whether the bitmap uses premultiplied alpha)doc";
 
 static const char *__doc_mitsuba_Bitmap_set_srgb_gamma = R"doc(Specify whether the bitmap uses an sRGB gamma encoding)doc";
 
@@ -3238,9 +3252,11 @@ static const char *__doc_mitsuba_Mesh_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_Mesh = R"doc(Create a new mesh with the given vertex and face data structures)doc";
 
-static const char *__doc_mitsuba_Mesh_Mesh_2 = R"doc()doc";
+static const char *__doc_mitsuba_Mesh_Mesh_2 = R"doc(Create a new mesh from a blender mesh)doc";
 
 static const char *__doc_mitsuba_Mesh_Mesh_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_Mesh_Mesh_4 = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_area_distr_build =
 R"doc(Build internal tables for sampling uniformly wrt. area.
@@ -3383,7 +3399,7 @@ static const char *__doc_mitsuba_Mesh_vertices = R"doc(Return a pointer to the r
 
 static const char *__doc_mitsuba_Mesh_vertices_2 = R"doc(Const variant of vertices.)doc";
 
-static const char *__doc_mitsuba_Mesh_write = R"doc(Export mesh using the file format implemented by the subclass)doc";
+static const char *__doc_mitsuba_Mesh_write_ply = R"doc(Export mesh as a binary PLY file)doc";
 
 static const char *__doc_mitsuba_MicrofacetDistribution =
 R"doc(Implementation of the Beckman and GGX / Trowbridge-Reitz microfacet
@@ -3555,8 +3571,6 @@ static const char *__doc_mitsuba_MonteCarloIntegrator_3 = R"doc()doc";
 static const char *__doc_mitsuba_MonteCarloIntegrator_MonteCarloIntegrator = R"doc(Create an integrator)doc";
 
 static const char *__doc_mitsuba_MonteCarloIntegrator_class = R"doc()doc";
-
-static const char *__doc_mitsuba_MonteCarloIntegrator_m_hide_emitters = R"doc()doc";
 
 static const char *__doc_mitsuba_MonteCarloIntegrator_m_max_depth = R"doc()doc";
 
@@ -4254,13 +4268,13 @@ static const char *__doc_mitsuba_Properties_string = R"doc(Retrieve a string val
 
 static const char *__doc_mitsuba_Properties_string_2 = R"doc(Retrieve a string value (use default value if no entry exists))doc";
 
-static const char *__doc_mitsuba_Properties_texture = R"doc(Retrieve a texture)doc";
+static const char *__doc_mitsuba_Properties_texture =
+R"doc(Retrieve a texture (if the property is a float, create a uniform
+texture instead))doc";
 
-static const char *__doc_mitsuba_Properties_texture_2 = R"doc(Retrieve a texture (use the provided spectrum if no entry exists))doc";
+static const char *__doc_mitsuba_Properties_texture_2 = R"doc(Retrieve a texture (use the provided texture if no entry exists))doc";
 
-static const char *__doc_mitsuba_Properties_texture_3 =
-R"doc(Retrieve a continuous spectrum (or create flat spectrum with default
-value))doc";
+static const char *__doc_mitsuba_Properties_texture_3 = R"doc(Retrieve a texture (or create uniform texture with default value))doc";
 
 static const char *__doc_mitsuba_Properties_transform = R"doc(Retrieve a 4x4 homogeneous coordinate transformation)doc";
 
@@ -4627,6 +4641,8 @@ May throw an exception if not supported. Cloning may also change the
 state of the original sampler (e.g. by using the next 1D sample as a
 seed for the clone).)doc";
 
+static const char *__doc_mitsuba_Sampler_m_base_seed = R"doc()doc";
+
 static const char *__doc_mitsuba_Sampler_m_sample_count = R"doc()doc";
 
 static const char *__doc_mitsuba_Sampler_next_1d = R"doc(Retrieve the next component value from the current sample)doc";
@@ -4669,6 +4685,8 @@ static const char *__doc_mitsuba_SamplingIntegrator_class = R"doc()doc";
 
 static const char *__doc_mitsuba_SamplingIntegrator_m_block_size = R"doc(Size of (square) image blocks to render per core.)doc";
 
+static const char *__doc_mitsuba_SamplingIntegrator_m_hide_emitters = R"doc(Flag for disabling direct visibility of emitters)doc";
+
 static const char *__doc_mitsuba_SamplingIntegrator_m_render_timer = R"doc(Timer used to enforce the timeout.)doc";
 
 static const char *__doc_mitsuba_SamplingIntegrator_m_samples_per_pass =
@@ -4703,6 +4721,10 @@ Parameter ``sampler``:
 Parameter ``ray``:
     A ray, optionally with differentials
 
+Parameter ``medium``:
+    If the ray is inside a medium, this parameter holds a pointer to
+    that medium
+
 Parameter ``active``:
     A mask that indicates which SIMD lanes are active
 
@@ -4724,7 +4746,8 @@ Returns:
 Remark:
     In the Python bindings, this function returns the ``aov`` output
     argument as an additional return value. In other words: `` (spec,
-    mask, aov) = integrator.sample(scene, sampler, ray, active) ``)doc";
+    mask, aov) = integrator.sample(scene, sampler, ray, medium,
+    active) ``)doc";
 
 static const char *__doc_mitsuba_SamplingIntegrator_should_stop =
 R"doc(Indicates whether cancel() or a timeout have occured. Should be
@@ -5120,7 +5143,10 @@ The implementation should fill in the fields ``p``, ``uv``, ``n``,
 ``has_uv_partials`` will already have been initialized by the caller.
 The field ``wi`` is initialized by the caller following the call to
 fill_surface_interaction(), and ``duv_dx``, and ``duv_dy`` are left
-uninitialized.)doc";
+uninitialized.
+
+Parameter ``cache``:
+    Cached information about the previously computed intersection.)doc";
 
 static const char *__doc_mitsuba_Shape_id = R"doc(Return a string identifier)doc";
 
@@ -5381,7 +5407,7 @@ static const char *__doc_mitsuba_Spiral_m_steps_left = R"doc(Step counters.)doc"
 static const char *__doc_mitsuba_Spiral_max_block_size = R"doc(Return the maximum block size)doc";
 
 static const char *__doc_mitsuba_Spiral_next_block =
-R"doc(Return the offset and size of the next block.
+R"doc(Return the offset, size and unique identifer of the next block.
 
 A size of zero indicates that the spiral traversal is done.)doc";
 
@@ -5697,6 +5723,8 @@ static const char *__doc_mitsuba_Struct_Field_type = R"doc(Type identifier)doc";
 
 static const char *__doc_mitsuba_Struct_Flags = R"doc(Field-specific flags)doc";
 
+static const char *__doc_mitsuba_Struct_Flags_Alpha = R"doc(Specifies whether the field encodes an alpha value)doc";
+
 static const char *__doc_mitsuba_Struct_Flags_Assert =
 R"doc(In FieldConverter::convert, check that the field value matches the
 specified default value. Otherwise, return a failure)doc";
@@ -5715,6 +5743,8 @@ static const char *__doc_mitsuba_Struct_Flags_Normalized =
 R"doc(Specifies whether an integer field encodes a normalized value in the
 range [0, 1]. The flag is ignored if specified for floating point
 valued fields.)doc";
+
+static const char *__doc_mitsuba_Struct_Flags_PremultipliedAlpha = R"doc(Specifies whether the field encodes an alpha premultiplied value)doc";
 
 static const char *__doc_mitsuba_Struct_Flags_Weight =
 R"doc(In FieldConverter::convert, when an input structure contains a weight
@@ -8204,37 +8234,37 @@ static const char *__doc_mitsuba_operator_lshift_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_lshift_3 = R"doc()doc";
 
-static const char *__doc_mitsuba_operator_lshift_4 = R"doc(Print a string representation of the bounding sphere)doc";
+static const char *__doc_mitsuba_operator_lshift_4 = R"doc()doc";
 
-static const char *__doc_mitsuba_operator_lshift_5 = R"doc()doc";
+static const char *__doc_mitsuba_operator_lshift_5 = R"doc(Print a string representation of the bounding sphere)doc";
 
 static const char *__doc_mitsuba_operator_lshift_6 = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_lshift_7 = R"doc()doc";
 
-static const char *__doc_mitsuba_operator_lshift_8 = R"doc(Return a string representation of a frame)doc";
+static const char *__doc_mitsuba_operator_lshift_8 = R"doc()doc";
 
-static const char *__doc_mitsuba_operator_lshift_9 = R"doc(Prints the canonical string representation of an object instance)doc";
+static const char *__doc_mitsuba_operator_lshift_9 = R"doc(Return a string representation of a frame)doc";
 
 static const char *__doc_mitsuba_operator_lshift_10 = R"doc(Prints the canonical string representation of an object instance)doc";
 
-static const char *__doc_mitsuba_operator_lshift_11 = R"doc(Return a string representation of the ray)doc";
+static const char *__doc_mitsuba_operator_lshift_11 = R"doc(Prints the canonical string representation of an object instance)doc";
 
-static const char *__doc_mitsuba_operator_lshift_12 = R"doc()doc";
+static const char *__doc_mitsuba_operator_lshift_12 = R"doc(Return a string representation of the ray)doc";
 
 static const char *__doc_mitsuba_operator_lshift_13 = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_lshift_14 = R"doc()doc";
 
-static const char *__doc_mitsuba_operator_lshift_15 = R"doc(//! @{ \name Printing)doc";
+static const char *__doc_mitsuba_operator_lshift_15 = R"doc()doc";
 
-static const char *__doc_mitsuba_operator_lshift_16 = R"doc()doc";
+static const char *__doc_mitsuba_operator_lshift_16 = R"doc(//! @{ \name Printing)doc";
 
 static const char *__doc_mitsuba_operator_lshift_17 = R"doc()doc";
 
-static const char *__doc_mitsuba_operator_lshift_18 = R"doc(//! @{ \name Misc implementations)doc";
+static const char *__doc_mitsuba_operator_lshift_18 = R"doc()doc";
 
-static const char *__doc_mitsuba_operator_lshift_19 = R"doc()doc";
+static const char *__doc_mitsuba_operator_lshift_19 = R"doc(//! @{ \name Misc implementations)doc";
 
 static const char *__doc_mitsuba_operator_lshift_20 = R"doc()doc";
 
@@ -8254,9 +8284,11 @@ static const char *__doc_mitsuba_operator_lshift_27 = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_lshift_28 = R"doc()doc";
 
+static const char *__doc_mitsuba_operator_lshift_29 = R"doc()doc";
+
 static const char *__doc_mitsuba_operator_sub = R"doc(Subtracting two points should always yield a vector)doc";
 
-static const char *__doc_mitsuba_operator_sub_2 = R"doc(Ssubtracting a vector from a point should always yield a point)doc";
+static const char *__doc_mitsuba_operator_sub_2 = R"doc(Subtracting a vector from a point should always yield a point)doc";
 
 static const char *__doc_mitsuba_parse_fov = R"doc(Helper function to parse fov)doc";
 

--- a/src/libcore/python/bitmap.cpp
+++ b/src/libcore/python/bitmap.cpp
@@ -33,6 +33,14 @@ MTS_PY_EXPORT(Bitmap) {
         .value("Unknown", Bitmap::FileFormat::Unknown, D(Bitmap, FileFormat, Unknown))
         .value("Auto",    Bitmap::FileFormat::Auto,    D(Bitmap, FileFormat, Auto));
 
+    py::enum_<Bitmap::AlphaTransform>(bitmap, "AlphaTransform")
+        .value("None",          Bitmap::AlphaTransform::None,
+                D(Bitmap, AlphaTransform, None))
+        .value("Premultiply",   Bitmap::AlphaTransform::Premultiply,
+                D(Bitmap, AlphaTransform, Premultiply))
+        .value("Unpremultiply", Bitmap::AlphaTransform::Unpremultiply,
+                D(Bitmap, AlphaTransform, Unpremultiply));
+
     bitmap.def(py::init<Bitmap::PixelFormat, Struct::Type, const Vector2u &, size_t>(),
             "pixel_format"_a, "component_format"_a, "size"_a, "channel_count"_a = 0,
             D(Bitmap, Bitmap))
@@ -77,6 +85,8 @@ MTS_PY_EXPORT(Bitmap) {
         .def_method(Bitmap, buffer_size)
         .def_method(Bitmap, srgb_gamma)
         .def_method(Bitmap, set_srgb_gamma)
+        .def_method(Bitmap, premultiplied_alpha)
+        .def_method(Bitmap, set_premultiplied_alpha)
         .def_method(Bitmap, clear)
         .def("metadata", py::overload_cast<>(&Bitmap::metadata), D(Bitmap, metadata),
             py::return_value_policy::reference_internal)
@@ -99,9 +109,9 @@ MTS_PY_EXPORT(Bitmap) {
             "clamp"_a = std::make_pair(-math::Infinity<Float>, math::Infinity<Float>),
             D(Bitmap, resample, 2)
         )
-        .def("convert", py::overload_cast<Bitmap::PixelFormat, Struct::Type, bool>(
+        .def("convert", py::overload_cast<Bitmap::PixelFormat, Struct::Type, bool, Bitmap::AlphaTransform>(
             &Bitmap::convert, py::const_), D(Bitmap, convert),
-            "pixel_format"_a, "component_format"_a, "srgb_gamma"_a,
+            "pixel_format"_a, "component_format"_a, "srgb_gamma"_a, "alpha_transform"_a = Bitmap::AlphaTransform::None,
             py::call_guard<py::gil_scoped_release>())
         .def("convert", py::overload_cast<Bitmap *>(&Bitmap::convert, py::const_),
             D(Bitmap, convert, 2), "target"_a,

--- a/src/libcore/python/struct.cpp
+++ b/src/libcore/python/struct.cpp
@@ -87,8 +87,12 @@ MTS_PY_EXPORT(Struct) {
         .value("Gamma",      Struct::Flags::Gamma,   D(Struct, Flags, Gamma))
         .value("Weight",     Struct::Flags::Weight,  D(Struct, Flags, Weight))
         .value("Assert",     Struct::Flags::Assert,  D(Struct, Flags, Assert))
+        .value("Alpha",     Struct::Flags::Alpha,  D(Struct, Flags, Alpha))
+        .value("PremultipliedAlpha",     Struct::Flags::PremultipliedAlpha,  D(Struct, Flags, PremultipliedAlpha))
         .value("Default",    Struct::Flags::Default, D(Struct, Flags, Default))
-        .def(py::self | py::self);
+        .def(py::self | py::self)
+        .def(int() | py::self)
+        .def(int() & py::self);
 
     py::enum_<Struct::ByteOrder>(c, "ByteOrder")
         .value("LittleEndian", Struct::ByteOrder::LittleEndian,

--- a/src/libcore/struct.cpp
+++ b/src/libcore/struct.cpp
@@ -1472,7 +1472,6 @@ bool StructConverter::load(const uint8_t *src, const Struct::Field &f, Value &va
 }
 
 void StructConverter::linearize(Value &value) const {
-    using Float = float;
 
     if (Struct::is_integer(value.type)) {
         if (Struct::is_unsigned(value.type))
@@ -1497,7 +1496,6 @@ void StructConverter::linearize(Value &value) const {
 }
 
 void StructConverter::save(uint8_t *dst, const Struct::Field &f, Value value, size_t x, size_t y) const {
-    using Float = float;
 
     /* Is swapping needed */
     bool target_swap = m_target->byte_order() != Struct::host_byte_order();
@@ -1620,7 +1618,6 @@ void StructConverter::save(uint8_t *dst, const Struct::Field &f, Value value, si
 
 bool StructConverter::convert_2d(size_t width, size_t height, const void *src_, void *dest_) const {
     using namespace mitsuba::detail;
-    using Float = float;
 
     size_t source_size = m_source->size();
     size_t target_size = m_target->size();

--- a/src/libcore/tests/test_bitmap.py
+++ b/src/libcore/tests/test_bitmap.py
@@ -106,6 +106,27 @@ def test_convert_rgb_y_gamma(tmpdir):
     assert np.allclose(b3, [to_srgb(0.212671)*255, to_srgb(0.715160)*255, to_srgb(0.072169)*255], atol=1)
 
 
+def test_premultiply_alpha(tmpdir):
+    # Tests RGBA(float64) -> Y (float32) conversion
+    b1 = Bitmap(Bitmap.PixelFormat.RGBA, Struct.Type.Float64, [3, 1])
+    assert b1.premultiplied_alpha()
+    b1.set_premultiplied_alpha(False)
+    assert not b1.premultiplied_alpha()
+
+    b2 = np.array(b1, copy=False)
+    b2[:] = [[[1, 0, 0, 1], [0, 1, 0, 0.5], [0, 0, 1, 0]]]
+
+    # Premultiply
+    b3 = np.array(b1.convert(Bitmap.PixelFormat.RGBA, Struct.Type.Float32, False, Bitmap.AlphaTransform.Premultiply)).ravel()
+    assert np.allclose(b3, [1.0, 0.0, 0.0, 1.0, 0.0, 0.5, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0])
+
+    # Unpremultiply
+    b1.set_premultiplied_alpha(True)
+    b3 = np.array(b1.convert(Bitmap.PixelFormat.RGBA, Struct.Type.Float32, False, Bitmap.AlphaTransform.Unpremultiply)).ravel()
+    assert np.allclose(b3, [1.0, 0.0, 0.0, 1.0, 0.0, 2, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0])
+
+
+
 def test_read_write_jpeg(tmpdir):
     np.random.seed(12345)
     tmp_file = os.path.join(str(tmpdir), "out.jpg")


### PR DESCRIPTION
This pull request adds support to handle premultiplied alpha  correctly when converting images. This is done by modifying the StructConverter to support the conversion operator and storing a "m_premultiplied_alpha" flag in Bitmap. 
