### PR TITLE
traverse() and parameters_changed() enhanced

### DIFF
--- a/include/mitsuba/core/object.h
+++ b/include/mitsuba/core/object.h
@@ -82,11 +82,18 @@ public:
      * internal state so that derived quantities are consistent with the
      * change.
      *
+     * \param keys
+     *     Optional list of names (obtained via \ref traverse) corresponding
+     *     to the attributes that have been modified. Can also be used to
+     *     notify when this function is called from a parent object by adding
+     *     a "parent" key to the list. When empty, the object should assume
+     *     that any attribute might have changed.
+     *
      * \remark The default implementation does nothing.
      *
      * \sa TraversalCallback
      */
-    virtual void parameters_changed();
+    virtual void parameters_changed(const std::vector<std::string> &/*keys*/ = {});
 
     /**
      * \brief Return a \ref Class instance containing run-time type information

--- a/include/mitsuba/core/string.h
+++ b/include/mitsuba/core/string.h
@@ -95,5 +95,8 @@ inline void replace_inplace(std::string &str, const std::string &source,
 extern MTS_EXPORT_CORE std::string trim(const std::string &s,
                                         const std::string &whitespace = " \t");
 
+/// Check if a list of keys contains a specific key
+extern MTS_EXPORT_CORE bool contains(const std::vector<std::string> &keys, const std::string &key);
+
 NAMESPACE_END(string)
 NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -14,7 +14,7 @@ template <typename Float, typename Spectrum>
 class MTS_EXPORT_RENDER Mesh : public Shape<Float, Spectrum> {
 public:
     MTS_IMPORT_TYPES()
-    MTS_IMPORT_BASE(Shape, m_mesh, set_children)
+    MTS_IMPORT_BASE(Shape, m_mesh, set_children, m_emitter)
 
     using InputFloat = float;
     using InputPoint3f  = Point<InputFloat, 3>;
@@ -284,7 +284,7 @@ public:
     /// Return the OptiX version of this shape
     virtual RTgeometrytriangles optix_geometry(RTcontext context) override;
     void traverse(TraversalCallback *callback) override;
-    void parameters_changed() override;
+    void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override;
 #endif
 
     /// @}

--- a/include/mitsuba/render/mesh.h
+++ b/include/mitsuba/render/mesh.h
@@ -14,7 +14,7 @@ template <typename Float, typename Spectrum>
 class MTS_EXPORT_RENDER Mesh : public Shape<Float, Spectrum> {
 public:
     MTS_IMPORT_TYPES()
-    MTS_IMPORT_BASE(Shape, m_mesh)
+    MTS_IMPORT_BASE(Shape, m_mesh, set_children)
 
     using InputFloat = float;
     using InputPoint3f  = Point<InputFloat, 3>;
@@ -275,10 +275,6 @@ public:
         return { active, u, v, t };
     }
 
-    void traverse(TraversalCallback *callback) override;
-
-    void parameters_changed() override;
-
 #if defined(MTS_ENABLE_EMBREE)
     /// Return the Embree version of this shape
     virtual RTCGeometry embree_geometry(RTCDevice device) const override;
@@ -287,6 +283,8 @@ public:
 #if defined(MTS_ENABLE_OPTIX)
     /// Return the OptiX version of this shape
     virtual RTgeometrytriangles optix_geometry(RTcontext context) override;
+    void traverse(TraversalCallback *callback) override;
+    void parameters_changed() override;
 #endif
 
     /// @}

--- a/include/mitsuba/render/scene.h
+++ b/include/mitsuba/render/scene.h
@@ -156,7 +156,7 @@ public:
     void traverse(TraversalCallback *callback) override;
 
     /// Update internal state following a parameter update
-    void parameters_changed() override;
+    void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override;
 
     /// Return a human-readable string representation of the scene contents.
     virtual std::string to_string() const override;

--- a/include/mitsuba/render/sensor.h
+++ b/include/mitsuba/render/sensor.h
@@ -119,9 +119,9 @@ public:
         callback->put_object("sampler", m_sampler.get());
     }
 
-    void parameters_changed() override {
-        m_aspect = m_film->size().x() / (ScalarFloat) m_film->size().y();
-        m_resolution = ScalarVector2f(m_film->crop_size());
+    void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
+            m_aspect = m_film->size().x() / (ScalarFloat) m_film->size().y();
+            m_resolution = ScalarVector2f(m_film->crop_size());
     }
 
     MTS_DECLARE_CLASS()

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -326,6 +326,8 @@ protected:
     inline Shape() { }
     virtual ~Shape();
 
+    /// Set this shape to its associated children
+    void set_children();
 protected:
     bool m_mesh = false;
     ref<BSDF> m_bsdf;

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -312,7 +312,7 @@ public:
 
     void traverse(TraversalCallback *callback) override;
 
-    void parameters_changed() override;
+    void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override;
 
     //! @}
     // =============================================================

--- a/src/bsdfs/blendbsdf.cpp
+++ b/src/bsdfs/blendbsdf.cpp
@@ -71,10 +71,6 @@ public:
         if (bsdf_index != 2)
             Throw("BlendBSDF: Two child BSDFs must be specified!");
 
-        parameters_changed();
-    }
-
-    void parameters_changed() override {
         m_components.clear();
         for (size_t i = 0; i < 2; ++i)
             for (size_t j = 0; j < m_nested_bsdf[i]->component_count(); ++j)

--- a/src/bsdfs/mask.cpp
+++ b/src/bsdfs/mask.cpp
@@ -80,10 +80,6 @@ public:
         if (!m_nested_bsdf)
            Throw("Child BSDF not specified");
 
-        parameters_changed();
-    }
-
-    void parameters_changed() override {
         m_components.clear();
         for (size_t i = 0; i < m_nested_bsdf->component_count(); ++i)
             m_components.push_back(m_nested_bsdf->flags(i));

--- a/src/bsdfs/plastic.cpp
+++ b/src/bsdfs/plastic.cpp
@@ -160,7 +160,7 @@ public:
         parameters_changed();
     }
 
-    void parameters_changed() override {
+    void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
         m_inv_eta_2 = 1.f / (m_eta * m_eta);
 
         // Numerically approximate the diffuse Fresnel reflectance

--- a/src/bsdfs/roughconductor.cpp
+++ b/src/bsdfs/roughconductor.cpp
@@ -185,10 +185,6 @@ public:
         if (props.has_property("specular_reflectance"))
             m_specular_reflectance = props.texture<Texture>("specular_reflectance", 1.f);
 
-        parameters_changed();
-    }
-
-    void parameters_changed() override {
         m_flags = BSDFFlags::GlossyReflection | BSDFFlags::FrontSide;
         if (m_alpha_u != m_alpha_v)
             m_flags = m_flags | BSDFFlags::Anisotropic;
@@ -398,7 +394,7 @@ public:
     }
 
     void traverse(TraversalCallback *callback) override {
-        if (m_alpha_u == m_alpha_v)
+        if (!has_flag(m_flags, BSDFFlags::Anisotropic))
             callback->put_object("alpha", m_alpha_u.get());
         else {
             callback->put_object("alpha_u", m_alpha_u.get());

--- a/src/bsdfs/roughdielectric.cpp
+++ b/src/bsdfs/roughdielectric.cpp
@@ -196,7 +196,7 @@ public:
         parameters_changed();
     }
 
-    void parameters_changed() override {
+    void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
         m_inv_eta = 1.f / m_eta;
     }
 

--- a/src/bsdfs/roughdielectric.cpp
+++ b/src/bsdfs/roughdielectric.cpp
@@ -451,7 +451,7 @@ public:
     }
 
     void traverse(TraversalCallback *callback) override {
-        if (m_alpha_u == m_alpha_v)
+        if (!has_flag(m_flags, BSDFFlags::Anisotropic))
             callback->put_object("alpha", m_alpha_u.get());
         else {
             callback->put_object("alpha_u", m_alpha_u.get());
@@ -470,8 +470,8 @@ public:
             << "  distribution = "           << m_type           << "," << std::endl
             << "  sample_visible = "         << (int) m_sample_visible << "," << std::endl;
 
-        if (m_alpha_u == m_alpha_v) {
-            oss << "  alpha_v = "                << string::indent(m_alpha_v) << "," << std::endl;
+        if (!has_flag(m_flags, BSDFFlags::Anisotropic)) {
+            oss << "  alpha = "                  << string::indent(m_alpha_v) << "," << std::endl;
         } else {
             oss << "  alpha_u = "                << string::indent(m_alpha_u) << "," << std::endl
                 << "  alpha_v = "                << string::indent(m_alpha_v) << "," << std::endl;

--- a/src/bsdfs/roughplastic.cpp
+++ b/src/bsdfs/roughplastic.cpp
@@ -196,7 +196,6 @@ public:
 
         m_specular_sampling_weight = s_mean / (d_mean + s_mean);
 
-
         /* Precompute rough reflectance (vectorized) */ {
             using FloatP    = Packet<ScalarFloat>;
             using Vector3fX = Vector<DynamicArray<FloatP>, 3>;

--- a/src/emitters/area.cpp
+++ b/src/emitters/area.cpp
@@ -61,9 +61,6 @@ public:
     }
 
     void set_shape(Shape *shape) override {
-        if (m_shape)
-            Throw("An area emitter can be only be attached to a single shape.");
-
         Base::set_shape(shape);
         m_area_times_pi = m_shape->surface_area() * math::Pi<ScalarFloat>;
     }
@@ -128,6 +125,10 @@ public:
 
     void traverse(TraversalCallback *callback) override {
         callback->put_object("radiance", m_radiance.get());
+    }
+
+    void parameters_changed() override {
+        m_area_times_pi = m_shape->surface_area() * math::Pi<ScalarFloat>;
     }
 
     std::string to_string() const override {

--- a/src/emitters/area.cpp
+++ b/src/emitters/area.cpp
@@ -61,6 +61,9 @@ public:
     }
 
     void set_shape(Shape *shape) override {
+        if (m_shape)
+            Throw("An area emitter can be only be attached to a single shape.");
+
         Base::set_shape(shape);
         m_area_times_pi = m_shape->surface_area() * math::Pi<ScalarFloat>;
     }
@@ -127,8 +130,9 @@ public:
         callback->put_object("radiance", m_radiance.get());
     }
 
-    void parameters_changed() override {
-        m_area_times_pi = m_shape->surface_area() * math::Pi<ScalarFloat>;
+    void parameters_changed(const std::vector<std::string> &keys) override {
+        if (string::contains(keys, "parent"))
+            m_area_times_pi = m_shape->surface_area() * math::Pi<ScalarFloat>;
     }
 
     std::string to_string() const override {

--- a/src/libcore/object.cpp
+++ b/src/libcore/object.cpp
@@ -22,7 +22,7 @@ std::vector<ref<Object>> Object::expand() const {
 
 void Object::traverse(TraversalCallback * /*callback*/) { }
 
-void Object::parameters_changed() { }
+void Object::parameters_changed(const std::vector<std::string> &/*keys*/) { }
 
 std::string Object::id() const { return std::string(); }
 

--- a/src/libcore/python/object.cpp
+++ b/src/libcore/python/object.cpp
@@ -50,7 +50,7 @@ MTS_PY_EXPORT(Object) {
             return l;
         }, D(Object, expand))
         .def_method(Object, traverse, "cb"_a)
-        .def_method(Object, parameters_changed)
+        .def_method(Object, parameters_changed, "keys"_a = py::list())
         .def_property_readonly("ptr", [](Object *self) { return (uintptr_t) self; })
         .def("class_", &Object::class_, py::return_value_policy::reference, D(Object, class))
         .def("__repr__", &Object::to_string, D(Object, to_string));

--- a/src/libcore/string.cpp
+++ b/src/libcore/string.cpp
@@ -52,5 +52,12 @@ std::string trim(const std::string &s, const std::string &whitespace) {
     return s.substr(it1, it2 - it1 + 1);
 }
 
+bool contains(const std::vector<std::string> &keys, const std::string &key) {
+    for (auto& k: keys)
+        if (k == key)
+            return true;
+    return false;
+}
+
 NAMESPACE_END(string)
 NAMESPACE_END(mitsuba)

--- a/src/librender/mesh.cpp
+++ b/src/librender/mesh.cpp
@@ -87,6 +87,7 @@ MTS_VARIANT Mesh<Float, Spectrum>::Mesh(const std::string &name, Struct *vertex_
     m_faces    = VertexHolder(new uint8_t[(face_count + 1) * m_face_size]);
 
     m_mesh = true;
+    set_children();
 }
 
 /**
@@ -314,6 +315,7 @@ MTS_VARIANT Mesh<Float, Spectrum>::Mesh(
         if (has_cols)
             store_unaligned(vertex_ptr + m_color_offset, tmp_cols[id]);
     }
+    set_children();
 }
 
 MTS_VARIANT Mesh<Float, Spectrum>::~Mesh() { }
@@ -898,6 +900,8 @@ MTS_VARIANT void Mesh<Float, Spectrum>::parameters_changed() {
 
         if (m_area_distr.empty())
             area_distr_build();
+
+        set_children();
     }
 }
 
@@ -1002,8 +1006,6 @@ MTS_VARIANT RTgeometrytriangles Mesh<Float, Spectrum>::optix_geometry(RTcontext 
 }
 
 MTS_VARIANT void Mesh<Float, Spectrum>::traverse(TraversalCallback *callback) {
-    Base::traverse(callback);
-
     if constexpr (is_cuda_array_v<Float>) {
         callback->put_parameter("vertex_count",     m_vertex_count);
         callback->put_parameter("face_count",       m_face_count);
@@ -1012,12 +1014,7 @@ MTS_VARIANT void Mesh<Float, Spectrum>::traverse(TraversalCallback *callback) {
         callback->put_parameter("vertex_normals",   m_optix->vertex_normals);
         callback->put_parameter("vertex_texcoords", m_optix->vertex_texcoords);
     }
-}
-
-#else // MTS_ENABLE_OPTIX off
-MTS_VARIANT void Mesh<Float, Spectrum>::parameters_changed() {
-}
-MTS_VARIANT void Mesh<Float, Spectrum>::traverse(TraversalCallback * /*callback*/) {
+    Base::traverse(callback);
 }
 #endif
 

--- a/src/librender/scene.cpp
+++ b/src/librender/scene.cpp
@@ -214,9 +214,9 @@ MTS_VARIANT void Scene<Float, Spectrum>::traverse(TraversalCallback *callback) {
     }
 }
 
-MTS_VARIANT void Scene<Float, Spectrum>::parameters_changed() {
+MTS_VARIANT void Scene<Float, Spectrum>::parameters_changed(const std::vector<std::string> &/*keys*/) {
     if (m_environment)
-        m_environment->set_scene(this);
+        m_environment->set_scene(this); // TODO use parameters_changed({"scene"})
 }
 
 MTS_VARIANT std::string Scene<Float, Spectrum>::to_string() const {

--- a/src/librender/shape.cpp
+++ b/src/librender/shape.cpp
@@ -339,7 +339,7 @@ MTS_VARIANT void Shape<Float, Spectrum>::traverse(TraversalCallback *callback) {
         callback->put_object("exterior_medium", m_exterior_medium.get());
 }
 
-MTS_VARIANT void Shape<Float, Spectrum>::parameters_changed() { }
+MTS_VARIANT void Shape<Float, Spectrum>::parameters_changed(const std::vector<std::string> &/*keys*/) { }
 
 MTS_VARIANT void Shape<Float, Spectrum>::set_children() {
     if (m_emitter)

--- a/src/librender/shape.cpp
+++ b/src/librender/shape.cpp
@@ -339,17 +339,14 @@ MTS_VARIANT void Shape<Float, Spectrum>::traverse(TraversalCallback *callback) {
         callback->put_object("exterior_medium", m_exterior_medium.get());
 }
 
-MTS_VARIANT void Shape<Float, Spectrum>::parameters_changed() {
-    m_bsdf->parameters_changed();
+MTS_VARIANT void Shape<Float, Spectrum>::parameters_changed() { }
+
+MTS_VARIANT void Shape<Float, Spectrum>::set_children() {
     if (m_emitter)
-        m_emitter->parameters_changed();
+        m_emitter->set_shape(this);
     if (m_sensor)
-        m_sensor->parameters_changed();
-    if (m_interior_medium)
-        m_interior_medium->parameters_changed();
-    if (m_exterior_medium)
-        m_exterior_medium->parameters_changed();
-}
+        m_sensor->set_shape(this);
+};
 
 MTS_IMPLEMENT_CLASS_VARIANT(Shape, Object, "shape")
 MTS_INSTANTIATE_CLASS(Shape)

--- a/src/sensors/irradiancemeter.cpp
+++ b/src/sensors/irradiancemeter.cpp
@@ -26,8 +26,8 @@ If the irradiance meter is attached to a mesh-type shape, it will measure the
 irradiance over all triangles in the mesh.
 
 This sensor is not instantiated on its own but must be defined as a child
-object to a shape in a scene. To create an irradiance meter, 
-simply instantiate the desired sensor shape and specify an 
+object to a shape in a scene. To create an irradiance meter,
+simply instantiate the desired sensor shape and specify an
 :monosp:`irradiancemeter` instance as its child:
 
 .. code-block:: xml
@@ -50,7 +50,7 @@ public:
             Throw("Found a 'to_world' transformation -- this is not allowed. "
                   "The irradiance meter inherits this transformation from its parent "
                   "shape.");
-        
+
         if (m_film->size() != ScalarPoint2i(1, 1))
             Throw("This sensor only supports films of size 1x1 Pixels!");
 
@@ -58,13 +58,6 @@ public:
             0.5f + math::RayEpsilon<Float>)
             Log(Warn, "This sensor should only be used with a reconstruction filter"
                "of radius 0.5 or lower(e.g. default box)");
-    }
-
-    void set_shape(Shape *shape) override {
-        if (m_shape)
-            Throw("An irradiance meter can be only be attached to a single shape.");
-
-        Base::set_shape(shape);
     }
 
     std::pair<RayDifferential3f, Spectrum>

--- a/src/sensors/perspective.cpp
+++ b/src/sensors/perspective.cpp
@@ -239,8 +239,8 @@ public:
         // TODO x_fov
     }
 
-    void parameters_changed() override {
-        Base::parameters_changed();
+    void parameters_changed(const std::vector<std::string> &keys) override {
+        Base::parameters_changed(keys);
         // TODO
     }
 

--- a/src/sensors/thinlens.cpp
+++ b/src/sensors/thinlens.cpp
@@ -266,8 +266,8 @@ public:
         // TODO aperture_radius, x_fov
     }
 
-    void parameters_changed() override {
-        Base::parameters_changed();
+    void parameters_changed(const std::vector<std::string> &keys) override {
+        Base::parameters_changed(keys);
         // TODO
     }
 

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -380,8 +380,9 @@ public:
     }
 
     void parameters_changed() override {
-        m_inv_surface_area = 1.f / surface_area();
-        set_children();
+        // TODO currently no parameters are exposed so nothing can change
+        // m_inv_surface_area = 1.f / surface_area();
+        // set_children();
     }
 
     std::string to_string() const override {

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -75,7 +75,7 @@ A simple example for instantiating a cylinder, whose interior is visible:
 template <typename Float, typename Spectrum>
 class Cylinder final : public Shape<Float, Spectrum> {
 public:
-    MTS_IMPORT_BASE(Shape, bsdf, emitter, is_emitter, sensor, is_sensor)
+    MTS_IMPORT_BASE(Shape, bsdf, emitter, is_emitter, sensor, is_sensor, set_children)
     MTS_IMPORT_TYPES()
 
     using typename Base::ScalarIndex;
@@ -114,10 +114,8 @@ public:
             m_radius = std::abs(m_radius);
             m_flip_normals = !m_flip_normals;
         }
-        if (is_emitter())
-            emitter()->set_shape(this);
-        if (is_sensor())
-            sensor()->set_shape(this);
+
+        set_children();
     }
 
     ScalarBoundingBox3f bbox() const override {
@@ -377,14 +375,13 @@ public:
     ScalarSize effective_primitive_count() const override { return 1; }
 
     void traverse(TraversalCallback *callback) override {
-        callback->put_parameter("radius", m_radius);
-        callback->put_parameter("length", m_length);
+        // TODO
         Base::traverse(callback);
     }
 
     void parameters_changed() override {
-        Base::parameters_changed();
         m_inv_surface_area = 1.f / surface_area();
+        set_children();
     }
 
     std::string to_string() const override {

--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -379,10 +379,11 @@ public:
         Base::traverse(callback);
     }
 
-    void parameters_changed() override {
+    void parameters_changed(const std::vector<std::string> &/*keys*/) override {
         // TODO currently no parameters are exposed so nothing can change
         // m_inv_surface_area = 1.f / surface_area();
-        // set_children();
+        // if (m_emitter)
+        //     m_emitter->parameters_changed({"parent"});
     }
 
     std::string to_string() const override {

--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -68,7 +68,7 @@ The following XML snippet instantiates an example of a textured disk shape:
 template <typename Float, typename Spectrum>
 class Disk final : public Shape<Float, Spectrum> {
 public:
-    MTS_IMPORT_BASE(Shape, bsdf, emitter, is_emitter, sensor, is_sensor)
+    MTS_IMPORT_BASE(Shape, bsdf, emitter, is_emitter, sensor, is_sensor, set_children)
     MTS_IMPORT_TYPES()
 
     using typename Base::ScalarSize;
@@ -96,10 +96,7 @@ public:
             Throw("The `to_world` transformation contains shear, which is not"
                   " supported by the Disk shape.");
 
-        if (is_emitter())
-            emitter()->set_shape(this);
-        if (is_sensor())
-            sensor()->set_shape(this);
+        set_children();
     }
 
     ScalarBoundingBox3f bbox() const override {
@@ -231,18 +228,16 @@ public:
     ScalarSize effective_primitive_count() const override { return 1; }
 
     void traverse(TraversalCallback *callback) override {
-        callback->put_parameter("frame", m_frame);
-        callback->put_parameter("du", m_du);
-        callback->put_parameter("dv", m_dv);
+        // TODO
         Base::traverse(callback);
     }
 
     void parameters_changed() override {
-        Base::parameters_changed();
         m_object_to_world = ScalarTransform4f::to_frame(m_frame)
                             * ScalarTransform4f::scale(ScalarVector3f(m_du, m_dv, 1.f));
         m_world_to_object = m_object_to_world.inverse();
         m_inv_surface_area = 1.f / surface_area();
+        set_children();
     }
 
     std::string to_string() const override {

--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -232,10 +232,11 @@ public:
         Base::traverse(callback);
     }
 
-    void parameters_changed() override {
+    void parameters_changed(const std::vector<std::string> &/*keys*/) override {
         // TODO currently no parameters are exposed so nothing can change
         // m_inv_surface_area = 1.f / surface_area();
-        // set_children();
+        // if (m_emitter)
+        //     m_emitter->parameters_changed({"parent"});
     }
 
     std::string to_string() const override {

--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -233,11 +233,9 @@ public:
     }
 
     void parameters_changed() override {
-        m_object_to_world = ScalarTransform4f::to_frame(m_frame)
-                            * ScalarTransform4f::scale(ScalarVector3f(m_du, m_dv, 1.f));
-        m_world_to_object = m_object_to_world.inverse();
-        m_inv_surface_area = 1.f / surface_area();
-        set_children();
+        // TODO currently no parameters are exposed so nothing can change
+        // m_inv_surface_area = 1.f / surface_area();
+        // set_children();
     }
 
     std::string to_string() const override {

--- a/src/shapes/obj.cpp
+++ b/src/shapes/obj.cpp
@@ -78,7 +78,7 @@ public:
                     m_texcoord_offset, m_color_offset, m_name, m_bbox, m_to_world, m_vertex_count,
                     m_face_count, m_vertex_struct, m_face_struct, m_disable_vertex_normals,
                     recompute_vertex_normals, is_emitter, emitter, sensor, is_sensor,
-                    has_vertex_normals, vertex)
+                    has_vertex_normals, vertex, set_children)
     MTS_IMPORT_TYPES()
 
     using typename Base::ScalarSize;
@@ -343,10 +343,7 @@ public:
         if (!m_disable_vertex_normals && normals.empty())
             recompute_vertex_normals();
 
-        if (is_emitter())
-            emitter()->set_shape(this);
-        if (is_sensor())
-            sensor()->set_shape(this);
+        set_children();
     }
 
     MTS_DECLARE_CLASS()

--- a/src/shapes/ply.cpp
+++ b/src/shapes/ply.cpp
@@ -55,7 +55,7 @@ public:
     MTS_IMPORT_BASE(Mesh, m_vertices, m_faces, m_normal_offset, m_vertex_size, m_face_size,
                     m_texcoord_offset, m_color_offset, m_name, m_bbox, m_to_world, m_vertex_count,
                     m_face_count, m_vertex_struct, m_face_struct, m_disable_vertex_normals,
-                    recompute_vertex_normals, is_emitter, emitter, is_sensor, sensor)
+                    recompute_vertex_normals, is_emitter, emitter, is_sensor, sensor, set_children)
     MTS_IMPORT_TYPES()
 
     using typename Base::ScalarSize;
@@ -282,10 +282,7 @@ public:
         if (!m_disable_vertex_normals && !has_vertex_normals)
             recompute_vertex_normals();
 
-        if (is_emitter())
-            emitter()->set_shape(this);
-        if (is_sensor())
-            sensor()->set_shape(this);
+        set_children();
     }
 
 private:

--- a/src/shapes/rectangle.cpp
+++ b/src/shapes/rectangle.cpp
@@ -254,10 +254,11 @@ public:
         Base::traverse(callback);
     }
 
-    void parameters_changed() override {
+    void parameters_changed(const std::vector<std::string> &/*keys*/) override {
         // TODO currently no parameters are exposed so nothing can change
         // m_inv_surface_area = 1.f / surface_area();
-        // set_children();
+        // if (m_emitter)
+        //     m_emitter->parameters_changed({"parent"});
     }
 
     std::string to_string() const override {

--- a/src/shapes/rectangle.cpp
+++ b/src/shapes/rectangle.cpp
@@ -69,7 +69,7 @@ The following XML snippet showcases a simple example of a textured rectangle:
 template <typename Float, typename Spectrum>
 class Rectangle final : public Shape<Float, Spectrum> {
 public:
-    MTS_IMPORT_BASE(Shape, bsdf, emitter, is_emitter, sensor, is_sensor)
+    MTS_IMPORT_BASE(Shape, bsdf, emitter, is_emitter, sensor, is_sensor, set_children)
     MTS_IMPORT_TYPES()
 
     using typename Base::ScalarSize;
@@ -96,10 +96,7 @@ public:
             Throw("The `to_world` transformation contains shear, which is not"
                   " supported by the Rectangle shape.");
 
-        if (is_emitter())
-            emitter()->set_shape(this);
-        if (is_sensor())
-            sensor()->set_shape(this);
+        set_children();
     }
 
     ScalarBoundingBox3f bbox() const override {
@@ -253,18 +250,16 @@ public:
     ScalarSize effective_primitive_count() const override { return 1; }
 
     void traverse(TraversalCallback *callback) override {
-        callback->put_parameter("frame", m_frame);
-        callback->put_parameter("du", m_du);
-        callback->put_parameter("dv", m_dv);
+        // TODO
         Base::traverse(callback);
     }
 
     void parameters_changed() override {
-        Base::parameters_changed();
         m_object_to_world = ScalarTransform4f::to_frame(m_frame) *
                             ScalarTransform4f::scale(ScalarVector3f(0.5f * m_du, 0.5f * m_dv, 1.f));
         m_world_to_object = m_object_to_world.inverse();
         m_inv_surface_area = 1.f / surface_area();
+        set_children();
     }
 
     std::string to_string() const override {

--- a/src/shapes/rectangle.cpp
+++ b/src/shapes/rectangle.cpp
@@ -255,11 +255,9 @@ public:
     }
 
     void parameters_changed() override {
-        m_object_to_world = ScalarTransform4f::to_frame(m_frame) *
-                            ScalarTransform4f::scale(ScalarVector3f(0.5f * m_du, 0.5f * m_dv, 1.f));
-        m_world_to_object = m_object_to_world.inverse();
-        m_inv_surface_area = 1.f / surface_area();
-        set_children();
+        // TODO currently no parameters are exposed so nothing can change
+        // m_inv_surface_area = 1.f / surface_area();
+        // set_children();
     }
 
     std::string to_string() const override {

--- a/src/shapes/serialized.cpp
+++ b/src/shapes/serialized.cpp
@@ -146,9 +146,9 @@ public:
     MTS_IMPORT_BASE(Mesh, m_vertices, m_faces, m_normal_offset, m_vertex_size, m_face_size,
                     m_texcoord_offset, m_color_offset, m_name, m_bbox, m_to_world, m_vertex_count,
                     m_face_count, m_vertex_struct, m_face_struct, m_disable_vertex_normals,
-                    recompute_vertex_normals, is_emitter, emitter, is_sensor, sensor, 
-                    vertex, has_vertex_normals, has_vertex_texcoords, vertex_texcoord, 
-                    vertex_normal, vertex_position)
+                    recompute_vertex_normals, is_emitter, emitter, is_sensor, sensor,
+                    vertex, has_vertex_normals, has_vertex_texcoords, vertex_texcoord,
+                    vertex_normal, vertex_position, set_children)
     MTS_IMPORT_TYPES()
 
     using typename Base::ScalarSize;
@@ -346,10 +346,7 @@ public:
         if (!m_disable_vertex_normals && !has_flag(flags, TriMeshFlags::HasNormals))
             recompute_vertex_normals();
 
-        if (is_emitter())
-            emitter()->set_shape(this);
-        if (is_sensor())
-            sensor()->set_shape(this);
+        set_children();
     }
 
     void read_helper(Stream *stream, bool dp, size_t offset, size_t dim) {

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -415,10 +415,9 @@ public:
     }
 
     void parameters_changed() override {
-        m_object_to_world = ScalarTransform4f::translate(m_center);
-        m_world_to_object = m_object_to_world.inverse();
-        m_inv_surface_area = 1.f / surface_area();
-        set_children();
+        // TODO currently no parameters are exposed so nothing can change
+        // m_inv_surface_area = 1.f / surface_area();
+        // set_children();
     }
 
 #if defined(MTS_ENABLE_EMBREE)

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -94,7 +94,7 @@ This makes it a good default choice for lighting new scenes.
 template <typename Float, typename Spectrum>
 class Sphere final : public Shape<Float, Spectrum> {
 public:
-    MTS_IMPORT_BASE(Shape, bsdf, emitter, is_emitter, sensor, is_sensor)
+    MTS_IMPORT_BASE(Shape, bsdf, emitter, is_emitter, sensor, is_sensor, set_children)
     MTS_IMPORT_TYPES()
 
     using typename Base::ScalarSize;
@@ -126,10 +126,7 @@ public:
             m_flip_normals = !m_flip_normals;
         }
 
-        if (is_emitter())
-            emitter()->set_shape(this);
-        if (is_sensor())
-            sensor()->set_shape(this);
+        set_children();
     }
 
     ScalarBoundingBox3f bbox() const override {
@@ -413,16 +410,15 @@ public:
     ScalarSize effective_primitive_count() const override { return 1; }
 
     void traverse(TraversalCallback *callback) override {
-        callback->put_parameter("center", m_center);
-        callback->put_parameter("radius", m_radius);
+        // TODO
         Base::traverse(callback);
     }
 
     void parameters_changed() override {
-        Base::parameters_changed();
         m_object_to_world = ScalarTransform4f::translate(m_center);
         m_world_to_object = m_object_to_world.inverse();
         m_inv_surface_area = 1.f / surface_area();
+        set_children();
     }
 
 #if defined(MTS_ENABLE_EMBREE)

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -414,10 +414,11 @@ public:
         Base::traverse(callback);
     }
 
-    void parameters_changed() override {
+    void parameters_changed(const std::vector<std::string> &/*keys*/) override {
         // TODO currently no parameters are exposed so nothing can change
         // m_inv_surface_area = 1.f / surface_area();
-        // set_children();
+        // if (m_emitter)
+        //     m_emitter->parameters_changed({"parent"});
     }
 
 #if defined(MTS_ENABLE_EMBREE)

--- a/src/spectra/blackbody.cpp
+++ b/src/spectra/blackbody.cpp
@@ -56,7 +56,7 @@ public:
         parameters_changed();
     }
 
-    void parameters_changed() override {
+    void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
         m_integral_min = cdf_and_pdf(ScalarFloat(MTS_WAVELENGTH_MIN)).first;
         m_integral = cdf_and_pdf(ScalarFloat(MTS_WAVELENGTH_MAX)).first - m_integral_min;
     }

--- a/src/spectra/irregular.cpp
+++ b/src/spectra/irregular.cpp
@@ -69,7 +69,7 @@ public:
         callback->put_parameter("values", m_distr.pdf());
     }
 
-    void parameters_changed() override {
+    void parameters_changed(const std::vector<std::string> &/*keys*/) override {
         m_distr.update();
     }
 

--- a/src/spectra/regular.cpp
+++ b/src/spectra/regular.cpp
@@ -61,7 +61,7 @@ public:
         callback->put_parameter("values", m_distr.pdf());
     }
 
-    void parameters_changed() override {
+    void parameters_changed(const std::vector<std::string> &/*keys*/) override {
         m_distr.update();
     }
 

--- a/src/spectra/srgb.cpp
+++ b/src/spectra/srgb.cpp
@@ -60,7 +60,7 @@ public:
         callback->put_parameter("value", m_value);
     }
 
-    void parameters_changed() override {
+    void parameters_changed(const std::vector<std::string> &/*keys*/) override {
         if constexpr (!is_spectral_v<Spectrum>)
             m_value = clamp(m_value, 0.f, 1.f);
     }

--- a/src/textures/bitmap.cpp
+++ b/src/textures/bitmap.cpp
@@ -272,42 +272,44 @@ public:
         callback->put_parameter("transform", m_transform);
     }
 
-    void parameters_changed() override {
-        /// Convert m_data into a managed array (available in CPU/GPU address space)
-        if constexpr (is_cuda_array_v<Float>)
-            m_data = m_data.managed();
+    void parameters_changed(const std::vector<std::string> &keys = {}) override {
+        if (keys.empty() || string::contains(keys, "data")) {
+            /// Convert m_data into a managed array (available in CPU/GPU address space)
+            if constexpr (is_cuda_array_v<Float>)
+                m_data = m_data.managed();
 
-        // Recompute the mean texture value following an update
-        ScalarFloat *ptr = m_data.data();
+            // Recompute the mean texture value following an update
+            ScalarFloat *ptr = m_data.data();
 
-        double mean = 0.0;
-        size_t pixel_count = hprod(m_resolution);
-        if (Channels == 3) {
-            if (is_spectral_v<Spectrum> && !Raw) {
-                for (size_t i = 0; i < pixel_count; ++i) {
-                    ScalarColor3f value = load_unaligned<ScalarColor3f>(ptr);
-                    mean += (double) srgb_model_mean(value);
-                    ptr += 3;
+            double mean = 0.0;
+            size_t pixel_count = hprod(m_resolution);
+            if (Channels == 3) {
+                if (is_spectral_v<Spectrum> && !Raw) {
+                    for (size_t i = 0; i < pixel_count; ++i) {
+                        ScalarColor3f value = load_unaligned<ScalarColor3f>(ptr);
+                        mean += (double) srgb_model_mean(value);
+                        ptr += 3;
+                    }
+                } else {
+                    for (size_t i = 0; i < pixel_count; ++i) {
+                        ScalarColor3f value = load_unaligned<ScalarColor3f>(ptr);
+                        value = clamp(value, 0.f, 1.f);
+                        store_unaligned(ptr, value);
+                        mean += (double) luminance(value);
+                        ptr += 3;
+                    }
                 }
             } else {
                 for (size_t i = 0; i < pixel_count; ++i) {
-                    ScalarColor3f value = load_unaligned<ScalarColor3f>(ptr);
+                    ScalarFloat value = ptr[i];
                     value = clamp(value, 0.f, 1.f);
-                    store_unaligned(ptr, value);
-                    mean += (double) luminance(value);
-                    ptr += 3;
+                    ptr[i] = value;
+                    mean += (double) value;
                 }
             }
-        } else {
-            for (size_t i = 0; i < pixel_count; ++i) {
-                ScalarFloat value = ptr[i];
-                value = clamp(value, 0.f, 1.f);
-                ptr[i] = value;
-                mean += (double) value;
-            }
-        }
 
-        m_mean = ScalarFloat(mean / pixel_count);
+            m_mean = ScalarFloat(mean / pixel_count);
+        }
     }
 
     ScalarFloat mean() const override { return m_mean; }

--- a/src/textures/grid3d.cpp
+++ b/src/textures/grid3d.cpp
@@ -350,7 +350,7 @@ public:
         Base::traverse(callback);
     }
 
-    void parameters_changed() override {
+    void parameters_changed(const std::vector<std::string> &/*keys*/) override {
         size_t new_size = data_size();
         if (m_size != new_size) {
             // Only support a special case: resolution doubling along all axes


### PR DESCRIPTION
## Overview

The primary goal of this PR is to enhance the traversal mechanism to prevent unnecessary updates of  the object parameters.

This is achieved by adding an optional argument to the `parameters_changed()`, carrying the list of names (a.k.a. `keys`) of the object's attributes that have being modified since the last call to this function.

These names correspond to the names given in the `traverse()` method.

When `keys` is empty, it should be assumed that any parameters might have been modified.

The implementation of the `parameters_changed` methods in every plugin can then be fine-tuned to avoid unnecessary computation when only a subset of the attributes have changed. For instance, we shouldn't recompute the optix BVH every time a mesh's BSDF reflectance value is modified (children trigger `parameters_changed()` on their parents).

`keys` might also contain the key `"parent"` (we could define a more "unique" key for this) which specifies that `parameters_changed()` has been called from a parent object. E.g., when a shape's geometry is modified, the attached `area`  emitter (if any) should be notified so it can recompute some internal variables (here `m_inv_surface_area`).

## Remaining questions

1. Objects defined at the root of the XML and later referenced will only be children of `Scene` and not children of the objects they are referenced by. This might cause some issues as "parents" might not be updated properly.
2. Should we be able to flag some parameters as `const` in `traverse()`? In which case `ParametersMap.__set_item__()` would throw an error / warning.

## TODOs

- [ ] `Scene` should upate its bounding sphere when some geometry is modified