### PR TITLE
Fix parallel execution of directional plugin test

### DIFF
--- a/src/emitters/tests/test_directional.py
+++ b/src/emitters/tests/test_directional.py
@@ -16,7 +16,7 @@ xml_spectrum = {
         """,
 }
 
-xml_spectrum_keys = list(set(xml_spectrum.keys()) - {"null"})
+xml_spectrum_keys = sorted(list(set(xml_spectrum.keys()) - {"null"}))
 
 
 def make_spectrum(spectrum_key="d65"):


### PR DESCRIPTION
This MR fixes a bug where the directional plugin test collection would fail when running pytest in parallel mode.