### PR TITLE
Fix missing ray update in radiancemeter plugin

### DIFF
--- a/src/sensors/radiancemeter.cpp
+++ b/src/sensors/radiancemeter.cpp
@@ -102,6 +102,8 @@ public:
         ray.o      = trafo.transform_affine(Point3f{ 0.f, 0.f, 0.f });
         ray.d      = trafo.transform_affine(Vector3f{ 0.f, 0.f, 1.f });
 
+        ray.update();
+
         return std::make_pair(ray, wav_weight);
     }
 


### PR DESCRIPTION
This small PR fixes a bug in the `radiancemeter` plugin where an omitted ray update would lead to invalid intersections.