### PR TITLE
Minor changes to directional

### DIFF
--- a/src/emitters/tests/test_directional.py
+++ b/src/emitters/tests/test_directional.py
@@ -130,25 +130,37 @@ def test_sample_direction(variant_scalar_spectral, spectrum_key, direction):
     assert ek.allclose(res, spec)
 
 
-@pytest.mark.parametrize("spatial_sample", [[0.85, 0.13], [0.16, 0.50], [0.00, 1.00]])
 @pytest.mark.parametrize("direction", [[0, 0, -1], [1, 1, 1], [0, 0, 1]])
-def test_sample_ray(variant_scalar_rgb, spatial_sample, direction):
+def test_sample_ray(variant_scalar_rgb, direction):
     import enoki as ek
     from mitsuba.core import Vector2f, Vector3f
 
     emitter = make_emitter(direction=direction)
     direction = Vector3f(direction)
-    
+
     time = 1.0
     wavelength_sample = 0.3
     directional_sample = [0.3, 0.2]
 
-    ray, wavelength = emitter.sample_ray(
-        time, wavelength_sample, spatial_sample, directional_sample)
+    for spatial_sample in [
+        [0.85, 0.13],
+        [0.16, 0.50],
+        [0.00, 1.00],
+        [0.32, 0.87],
+        [0.16, 0.44],
+        [0.17, 0.44],
+        [0.22, 0.81],
+        [0.12, 0.82],
+        [0.99, 0.42],
+        [0.72, 0.40],
+        [0.01, 0.61],
+    ]:
+        ray, _ = emitter.sample_ray(
+            time, wavelength_sample, spatial_sample, directional_sample)
 
-    # Check that ray direction is what is expected
-    assert ek.allclose(ray.d, direction / ek.norm(direction))
+        # Check that ray direction is what is expected
+        assert ek.allclose(ray.d, direction / ek.norm(direction))
 
-    # Check that ray origin is outside of bounding sphere
-    # Bounding sphere is centered at world origin and has radius 1 without scene
-    assert ek.norm(ray.o) >= 1.
+        # Check that ray origin is outside of bounding sphere
+        # Bounding sphere is centered at world origin and has radius 1 without scene
+        assert ek.norm(ray.o) >= 1.


### PR DESCRIPTION
Here are a couple of changes I made to `directional` I'd like some feedback on:

1. Since only 2 samples are used by `sample_ray()`, I set `m_needs_sample_3` to `false`.
2. When writing this plugin, I copied the importance weight value from `constant` and set its factor to <img src="https://render.githubusercontent.com/render/math?math=4 (\pi r)^2">. However, it seems like it is proportional to the bounding sphere's surface area <img src="https://render.githubusercontent.com/render/math?math=4 \pi r^2"> (this is in the tweaks I made). I'm not quite sure about this, I actually don't understand how this value is chosen so I'd like to know if it actually matters :)

I also happened to test a distant directional sensor plugin with more samples so I added these to `directional`'s tests. Which makes me think: would such a sensor be of use to the community?