### PR TITLE
Minor fixes to radiancemeter plugin

### DIFF
--- a/src/sensors/radiancemeter.cpp
+++ b/src/sensors/radiancemeter.cpp
@@ -48,7 +48,8 @@ priority.
 
 MTS_VARIANT class RadianceMeter final : public Sensor<Float, Spectrum> {
 public:
-    MTS_IMPORT_BASE(Sensor, m_film, m_world_transform)
+    MTS_IMPORT_BASE(Sensor, m_film, m_world_transform, m_needs_sample_2,
+                    m_needs_sample_3)
     MTS_IMPORT_TYPES()
 
     RadianceMeter(const Properties &props) : Base(props) {
@@ -82,6 +83,9 @@ public:
             0.5f + math::RayEpsilon<Float>)
             Log(Warn, "This sensor should be used with a reconstruction filter "
                       "with a radius of 0.5 or lower (e.g. default box)");
+
+        m_needs_sample_2 = false;
+        m_needs_sample_3 = false;
     }
 
     std::pair<Ray3f, Spectrum> sample_ray(Float time, Float wavelength_sample,
@@ -129,6 +133,8 @@ public:
         // 3. Set differentials; since the film size is always 1x1, we don't
         //    have differentials
         ray.has_differentials = false;
+
+        ray.update();
 
         return std::make_pair(ray, wav_weight);
     }

--- a/src/sensors/tests/test_irradiancemeter.py
+++ b/src/sensors/tests/test_irradiancemeter.py
@@ -9,7 +9,7 @@ def example_shape(radius, center):
     from mitsuba.core.xml import load_string
 
     xml = f"""
-    <shape version='0.1.0' type="sphere">
+    <shape version='2.0.0' type="sphere">
         <float name="radius" value="{radius}"/>
         <transform name="to_world">
             <translate x="{center.x}" y="{center.y}" z="{center.z}"/>
@@ -81,7 +81,7 @@ def test_incoming_flux(variant_scalar_rgb, radiance):
     from mitsuba.core.xml import load_string
 
     sensor_xml = f"""
-    <shape version='0.1.0' type="sphere">
+    <shape version='2.0.0' type="sphere">
         <float name="radius" value="1"/>
         <transform name="to_world">
             <translate x="0" y="0" z="0"/>
@@ -104,7 +104,7 @@ def test_incoming_flux(variant_scalar_rgb, radiance):
     """
 
     scene_xml = f"""
-        <scene version="0.1.0">
+        <scene version="2.0.0">
             {sensor_xml}
             {emitter_xml}
         </scene>
@@ -144,7 +144,7 @@ def test_incoming_flux_integrator(variant_scalar_rgb, radiance):
     from mitsuba.core.xml import load_string
 
     sensor_xml = f"""
-    <shape version='0.1.0' type="sphere">
+    <shape version='2.0.0' type="sphere">
         <float name="radius" value="1"/>
         <transform name="to_world">
             <translate x="0" y="0" z="0"/>
@@ -179,7 +179,7 @@ def test_incoming_flux_integrator(variant_scalar_rgb, radiance):
      </sampler>
     """
     scene_xml = f"""
-        <scene version="0.1.0">
+        <scene version="2.0.0">
             {integrator_xml}
             {sensor_xml}
             {emitter_xml}


### PR DESCRIPTION
This small PR fixes a bug in the `radiancemeter` plugin where an omitted ray update would lead to invalid intersections (it is the same as in #121, I forgot to update `sample_ray_differential` in that PR).

In addition, I set the `m_needs_sample_2` and `m_needs_sample_3` members to `false`.

Edit: I also fixed wrong `version` tags in the `irradiancemeter` plugin tests.