### PR TITLE
XML resource path

### DIFF
--- a/docs/src/getting_started/file_format.rst
+++ b/docs/src/getting_started/file_format.rst
@@ -407,7 +407,6 @@ precedence when no command line arguments are given. The syntax for this is:
 
 and must precede the occurrences of the parameter in the XML file.
 
-
 Including external files
 ------------------------
 
@@ -444,3 +443,14 @@ can be accomplished using the ``alias as=".."`` tag:
 After this statement, the diffuse scattering model will be bound to *both*
 identifiers ``my_material_1`` and ``my_material_2``.
 
+External resource folders
+-------------------------
+
+Using the ``path`` tag, it is possible to add a path to the list of search paths. This can
+be useful for instance when some meshes and textures are stored in a different directory, (e.g. when
+shared with other scenes). The path can be absolute, relative to the directory containing the XML
+scene file, or relative to any path already existing in the list of search paths.
+
+.. code-block:: xml
+
+    <path value="../../my_resources"/>

--- a/docs/src/getting_started/file_format.rst
+++ b/docs/src/getting_started/file_format.rst
@@ -448,8 +448,9 @@ External resource folders
 
 Using the ``path`` tag, it is possible to add a path to the list of search paths. This can
 be useful for instance when some meshes and textures are stored in a different directory, (e.g. when
-shared with other scenes). The path can be absolute, relative to the directory containing the XML
-scene file, or relative to any path already existing in the list of search paths.
+shared with other scenes). If the path is a relative path, Mitsuba 2 will first try to interpret it
+relative to the scene directory, then to other paths that are already on the search path (e.g. added
+using the ``-a <path1>;<path2>;..`` command line argument).
 
 .. code-block:: xml
 

--- a/src/libcore/tests/test_dict.py
+++ b/src/libcore/tests/test_dict.py
@@ -447,14 +447,14 @@ def test10_dict_expand_nested_object(variant_scalar_rgb):
         "type" : "diffuse",
         "reflectance" : {
             "type" : "bitmap",
-            "filename" : "resources/data/envmap/museum.exr"
+            "filename" : "resources/data/common/textures/museum.exr"
         }
     })
 
     b1 = xml.load_string("""
         <bsdf type="diffuse" version="2.0.0">
             <texture type="bitmap" name="reflectance">
-                <string name="filename" value="resources/data/envmap/museum.exr"/>
+                <string name="filename" value="resources/data/common/textures/museum.exr"/>
             </texture>
         </bsdf>
     """)
@@ -464,7 +464,7 @@ def test10_dict_expand_nested_object(variant_scalar_rgb):
     # Check that root object isn't expanded
     texture = xml.load_dict({
             "type" : "bitmap",
-            "filename" : "resources/data/envmap/museum.exr"
+            "filename" : "resources/data/common/textures/museum.exr"
     })
     assert len(texture.expand()) == 1
 
@@ -480,7 +480,7 @@ def test10_dict_expand_nested_object(variant_scalar_rgb):
         "type" : "scene",
         "mytexture" : {
             "type" : "bitmap",
-            "filename" : "resources/data/envmap/museum.exr"
+            "filename" : "resources/data/common/textures/museum.exr"
         },
         "shape1" : {
             "type" : "sphere",

--- a/src/libcore/tests/test_write_xml.py
+++ b/src/libcore/tests/test_write_xml.py
@@ -164,7 +164,7 @@ def test05_xml_split(variant_scalar_rgb):
         },
         'envmap': {
             'type': 'envmap',
-            'filename': 'resources/data/envmap/museum.exr'
+            'filename': 'resources/data/common/textures/museum.exr'
         },
         'shape':{
             'type': 'sphere',

--- a/src/libcore/tests/test_xml.py
+++ b/src/libcore/tests/test_xml.py
@@ -298,3 +298,28 @@ def test20_upgrade_tree(variant_scalar_rgb):
                                <float name="intIOR" value="1.33"/>
                            </bsdf>
                        </scene>""")
+
+
+def test21_path_at_root_only(variant_scalar_rgb):
+    from mitsuba.core import xml
+
+    err_str = 'can only be child of root'
+    with pytest.raises(Exception) as e:
+        xml.load_string("""<scene version="2.0.0">
+                            <bsdf type="dielectric">
+                                <path value="/tmp"/>
+                            </bsdf>
+                        </scene>""")
+    e.match(err_str)
+
+
+def test22_fileresolver_unchanged(variant_scalar_rgb):
+    from mitsuba.core import xml, Thread
+
+    fs_backup = Thread.thread().file_resolver()
+
+    xml.load_string("""<scene version="2.0.0">
+                            <path value="/tmp"/>
+                        </scene>""")
+
+    assert fs_backup == Thread.thread().file_resolver()

--- a/src/libcore/xml.cpp
+++ b/src/libcore/xml.cpp
@@ -37,7 +37,7 @@ NAMESPACE_BEGIN(xml)
 enum class Tag {
     Boolean, Integer, Float, String, Point, Vector, Spectrum, RGB,
     Transform, Translate, Matrix, Rotate, Scale, LookAt, Object,
-    NamedReference, Include, Alias, Default, Invalid
+    NamedReference, Include, Alias, Default, Resource, Invalid
 };
 
 struct Version {
@@ -129,24 +129,25 @@ void register_class(const Class *class_) {
         tag_class = new std::unordered_map<std::string, const Class *>();
 
         // Create an initial mapping of tag names to IDs
-        (*tags)["boolean"]    = Tag::Boolean;
-        (*tags)["integer"]    = Tag::Integer;
-        (*tags)["float"]      = Tag::Float;
-        (*tags)["string"]     = Tag::String;
-        (*tags)["point"]      = Tag::Point;
-        (*tags)["vector"]     = Tag::Vector;
-        (*tags)["transform"]  = Tag::Transform;
-        (*tags)["translate"]  = Tag::Translate;
-        (*tags)["matrix"]     = Tag::Matrix;
-        (*tags)["rotate"]     = Tag::Rotate;
-        (*tags)["scale"]      = Tag::Scale;
-        (*tags)["lookat"]     = Tag::LookAt;
-        (*tags)["ref"]        = Tag::NamedReference;
-        (*tags)["spectrum"]   = Tag::Spectrum;
-        (*tags)["rgb"]        = Tag::RGB;
-        (*tags)["include"]    = Tag::Include;
-        (*tags)["alias"]      = Tag::Alias;
-        (*tags)["default"]    = Tag::Default;
+        (*tags)["boolean"]       = Tag::Boolean;
+        (*tags)["integer"]       = Tag::Integer;
+        (*tags)["float"]         = Tag::Float;
+        (*tags)["string"]        = Tag::String;
+        (*tags)["point"]         = Tag::Point;
+        (*tags)["vector"]        = Tag::Vector;
+        (*tags)["transform"]     = Tag::Transform;
+        (*tags)["translate"]     = Tag::Translate;
+        (*tags)["matrix"]        = Tag::Matrix;
+        (*tags)["rotate"]        = Tag::Rotate;
+        (*tags)["scale"]         = Tag::Scale;
+        (*tags)["lookat"]        = Tag::LookAt;
+        (*tags)["ref"]           = Tag::NamedReference;
+        (*tags)["spectrum"]      = Tag::Spectrum;
+        (*tags)["rgb"]           = Tag::RGB;
+        (*tags)["include"]       = Tag::Include;
+        (*tags)["alias"]         = Tag::Alias;
+        (*tags)["default"]       = Tag::Default;
+        (*tags)["path"]          = Tag::Resource;
     }
 
     // Register the new class as an object tag
@@ -625,6 +626,26 @@ static std::pair<std::string, std::string> parse_xml(XMLSource &src, XMLParseCon
                     }
                     if (!found)
                         param.emplace_back(name, value);
+                    return std::make_pair("", "");
+                }
+                break;
+
+            case Tag::Resource: {
+                    check_attributes(src, node, { "value" });
+                    if (depth != 1)
+                        src.throw_error(node, "<path>: path can only be child of root");
+                    ref<FileResolver> fs = Thread::thread()->file_resolver();
+                    fs::path resource_path(node.attribute("value").value());
+                    if (!resource_path.is_absolute()) {
+                        // First try to resolve it starting in the XML file directory
+                        resource_path = fs::path(src.id).parent_path() / resource_path;
+                        // Otherwise try to resolve it with the FileResolver
+                        if (!fs::exists(resource_path))
+                            resource_path = fs->resolve(node.attribute("value").value());
+                    }
+                    if (!fs::exists(resource_path))
+                        src.throw_error(node, "<path>: folder \"%s\" not found", resource_path);
+                    fs->prepend(resource_path);
                     return std::make_pair("", "");
                 }
                 break;
@@ -1170,13 +1191,24 @@ ref<Object> load_string(const std::string &string, const std::string &variant,
         Throw("Error while loading \"%s\" (at %s): %s", src.id,
               src.offset(result.offset), result.description());
 
-    pugi::xml_node root = doc.document_element();
-    detail::XMLParseContext ctx(variant);
-    Properties prop;
-    size_t arg_counter; // Unused
-    auto scene_id = detail::parse_xml(src, ctx, root, Tag::Invalid, prop,
-                                      param, arg_counter, 0).second;
-    return detail::instantiate_node(ctx, scene_id);
+    // Make a backup copy of the FileResolver, which will be restored after parsing
+    ref<FileResolver> fs_backup = Thread::thread()->file_resolver();
+    Thread::thread()->set_file_resolver(new FileResolver(*fs_backup));
+
+    try {
+        pugi::xml_node root = doc.document_element();
+        detail::XMLParseContext ctx(variant);
+        Properties prop;
+        size_t arg_counter; // Unused
+        auto scene_id = detail::parse_xml(src, ctx, root, Tag::Invalid, prop,
+                                          param, arg_counter, 0).second;
+        ref<Object> obj = detail::instantiate_node(ctx, scene_id);
+        Thread::thread()->set_file_resolver(fs_backup.get());
+        return obj;
+    } catch(...) {
+        Thread::thread()->set_file_resolver(fs_backup.get());
+        throw;
+    }
 }
 
 ref<Object> load_file(const fs::path &filename_, const std::string &variant,
@@ -1203,39 +1235,49 @@ ref<Object> load_file(const fs::path &filename_, const std::string &variant,
         Throw("Error while loading \"%s\" (at %s): %s", src.id,
               src.offset(result.offset), result.description());
 
-    pugi::xml_node root = doc.document_element();
+    // Make a backup copy of the FileResolver, which will be restored after parsing
+    ref<FileResolver> fs_backup = Thread::thread()->file_resolver();
+    Thread::thread()->set_file_resolver(new FileResolver(*fs_backup));
 
-    detail::XMLParseContext ctx(variant);
-    Properties prop;
-    size_t arg_counter = 0; // Unused
-    auto scene_id = detail::parse_xml(src, ctx, root, Tag::Invalid, prop,
-                                      param, arg_counter, 0).second;
+    try {
+        pugi::xml_node root = doc.document_element();
+        detail::XMLParseContext ctx(variant);
+        Properties prop;
+        size_t arg_counter = 0; // Unused
+        auto scene_id = detail::parse_xml(src, ctx, root, Tag::Invalid, prop,
+                                          param, arg_counter, 0).second;
 
-    if (src.modified && write_update) {
-        fs::path backup = filename;
-        backup.replace_extension(".bak");
-        Log(Info, "Writing updated \"%s\" .. (backup at \"%s\")", filename, backup);
-        if (!fs::rename(filename, backup))
-            Throw("Unable to rename file \"%s\" to \"%s\"!", filename, backup);
+        if (src.modified && write_update) {
+            fs::path backup = filename;
+            backup.replace_extension(".bak");
+            Log(Info, "Writing updated \"%s\" .. (backup at \"%s\")", filename, backup);
+            if (!fs::rename(filename, backup))
+                Throw("Unable to rename file \"%s\" to \"%s\"!", filename, backup);
 
-        // Update version number
-        root.prepend_attribute("version").set_value(MTS_VERSION);
-        if (root.attribute("type").value() == std::string("scene"))
-            root.remove_attribute("type");
+            // Update version number
+            root.prepend_attribute("version").set_value(MTS_VERSION);
+            if (root.attribute("type").value() == std::string("scene"))
+                root.remove_attribute("type");
 
-        // Strip anonymous IDs/names
-        for (pugi::xpath_node result2: doc.select_nodes("//*[starts-with(@id, '_unnamed_')]"))
-            result2.node().remove_attribute("id");
-        for (pugi::xpath_node result2: doc.select_nodes("//*[starts-with(@name, '_arg_')]"))
-            result2.node().remove_attribute("name");
+            // Strip anonymous IDs/names
+            for (pugi::xpath_node result2: doc.select_nodes("//*[starts-with(@id, '_unnamed_')]"))
+                result2.node().remove_attribute("id");
+            for (pugi::xpath_node result2: doc.select_nodes("//*[starts-with(@name, '_arg_')]"))
+                result2.node().remove_attribute("name");
 
-        doc.save_file(filename.native().c_str(), "    ");
+            doc.save_file(filename.native().c_str(), "    ");
 
-        // Update for detail::file_offset
-        filename = backup;
+            // Update for detail::file_offset
+            filename = backup;
+        }
+
+        ref<Object> obj = detail::instantiate_node(ctx, scene_id);
+        Thread::thread()->set_file_resolver(fs_backup.get());
+        return obj;
+    } catch(...) {
+        Thread::thread()->set_file_resolver(fs_backup.get());
+        throw;
     }
-
-    return detail::instantiate_node(ctx, scene_id);
 }
 
 NAMESPACE_END(xml)

--- a/src/librender/tests/test_integrator.py
+++ b/src/librender/tests/test_integrator.py
@@ -16,7 +16,6 @@ integrators = [
     ]
 ]
 
-
 def make_integrator(kind, xml=""):
     from mitsuba.core.xml import load_string
     integrator = load_string("<integrator version='2.0.0' type='%s'>"

--- a/src/librender/tests/test_kdtrees.py
+++ b/src/librender/tests/test_kdtrees.py
@@ -71,7 +71,7 @@ def test02_depth_scalar_bunny(variant_scalar_rgb):
     scene = load_string("""
         <scene version="0.5.0">
             <shape type="ply">
-                <string name="filename" value="resources/data/ply/bunny_lowres.ply"/>
+                <string name="filename" value="resources/data/common/meshes/bunny_lowres.ply"/>
             </shape>
         </scene>
     """)

--- a/src/mitsuba/mitsuba.cpp
+++ b/src/mitsuba/mitsuba.cpp
@@ -46,6 +46,7 @@ Options:
 
         Available modes:
               )" << string::indent(MTS_VARIANTS, 14) << R"(
+
     -v, --verbose
         Be more verbose. (can be specified multiple times)
 
@@ -63,6 +64,9 @@ Options:
     -u, --update
         When specified, Mitsuba will update the scene's
         XML description to the latest version.
+
+    -a <path1>;<path2>;..
+        Add one or more entries to the resource search path.
 
     -o <filename>, --output <filename>
         Write the output image to the file "filename".
@@ -137,6 +141,7 @@ int main(int argc, char *argv[]) {
     auto arg_update    = parser.add(StringVec{ "-u", "--update" }, false);
     auto arg_help      = parser.add(StringVec{ "-h", "--help" });
     auto arg_mode      = parser.add(StringVec{ "-m", "--mode" }, true);
+    auto arg_paths     = parser.add(StringVec{ "-a" }, true);
     auto arg_extra     = parser.add("", true);
     bool print_profile = false;
     xml::ParameterList params;
@@ -197,6 +202,15 @@ int main(int argc, char *argv[]) {
         filesystem::path base_path = util::library_path().parent_path();
         if (!fr->contains(base_path))
             fr->append(base_path);
+
+        // Append extra paths from command line arguments to the FileResolver search path list
+        if (*arg_paths) {
+            auto extra_paths = string::tokenize(arg_paths->as_string(), ";");
+            for (auto& path : extra_paths) {
+                if (!fr->contains(path))
+                    fr->append(path);
+            }
+        }
 
         if (!*arg_extra || *arg_help) {
             help((int) __global_thread_count);

--- a/src/phase/tests/test_trampoline.py
+++ b/src/phase/tests/test_trampoline.py
@@ -55,7 +55,7 @@ def create_medium_scene(phase_function='isotropic', spp=8):
             </sensor>
             <emitter type="constant" />
             <shape type="ply">
-                <string name="filename" value="resources/data/ply/teapot.ply"/>
+                <string name="filename" value="resources/data/common/meshes/teapot.ply"/>
                 <bsdf type="null" />
                 <medium name="interior" type="homogeneous">
                     <rgb name="sigma_t" value="1.0, 1.0, 1.0"/>

--- a/src/python/python/test/scenes.py
+++ b/src/python/python/test/scenes.py
@@ -56,7 +56,7 @@ def make_teapot_scene(spp = 32):
 
             <shape type="ply">
                 <string name="filename"
-                        value="resources/data/ply/teapot.ply"/>
+                        value="resources/data/common/meshes/teapot.ply"/>
 
                 <bsdf type="diffuse">
                     <rgb name="reflectance" value="0.1, 0.1, 0.8"/>
@@ -111,7 +111,7 @@ def make_box_scene(spp = 16):
             </bsdf>
 
             <shape type="ply">
-                <string name="filename" value="resources/data/ply/teapot.ply"/>
+                <string name="filename" value="resources/data/common/meshes/teapot.ply"/>
                 <transform name="to_world">
                     <translate x="0" y="0" z="0.15"/>
                 </transform>
@@ -119,7 +119,7 @@ def make_box_scene(spp = 16):
             </shape>
 
             <shape type="obj"> <!-- Bottom -->
-                <string name="filename" value="resources/data/obj/rectangle.obj"/>
+                <string name="filename" value="resources/data/common/meshes/rectangle.obj"/>
                 <transform name="to_world">
                     <scale x="5" y="5" z="5"/>
                 </transform>
@@ -127,7 +127,7 @@ def make_box_scene(spp = 16):
             </shape>
 
             <shape type="obj">  <!-- Left -->
-                <string name="filename" value="resources/data/obj/rectangle.obj"/>
+                <string name="filename" value="resources/data/common/meshes/rectangle.obj"/>
                 <transform name="to_world">
                     <scale x="5" y="5" z="5"/>
                     <rotate x="0" y="1" z="0" angle="90"/>
@@ -139,7 +139,7 @@ def make_box_scene(spp = 16):
             </shape>
 
             <shape type="obj">  <!-- Back -->
-                <string name="filename" value="resources/data/obj/rectangle.obj"/>
+                <string name="filename" value="resources/data/common/meshes/rectangle.obj"/>
                 <transform name="to_world">
                     <scale x="5" y="5" z="5"/>
                     <rotate x="1" y="0" z="0" angle="90"/>
@@ -149,7 +149,7 @@ def make_box_scene(spp = 16):
             </shape>
 
             <shape type="obj">  <!-- Right -->
-                <string name="filename" value="resources/data/obj/rectangle.obj"/>
+                <string name="filename" value="resources/data/common/meshes/rectangle.obj"/>
                 <transform name="to_world">
                     <scale x="5" y="5" z="5"/>
                     <rotate x="0" y="1" z="0" angle="-90"/>
@@ -161,7 +161,7 @@ def make_box_scene(spp = 16):
             </shape>
 
             <shape type="obj">  <!-- Top -->
-                <string name="filename" value="resources/data/obj/rectangle.obj"/>
+                <string name="filename" value="resources/data/common/meshes/rectangle.obj"/>
                 <transform name="to_world">
                     <scale x="5" y="5" z="5"/>
                     <rotate x="0" y="1" z="0" angle="180"/>
@@ -171,7 +171,7 @@ def make_box_scene(spp = 16):
             </shape>
 
             <shape type="obj">  <!-- Small emitter -->
-                <string name="filename" value="resources/data/obj/rectangle.obj"/>
+                <string name="filename" value="resources/data/common/meshes/rectangle.obj"/>
                 <transform name="to_world">
                     <scale x="3" y="3" z="3"/>
                     <rotate x="0" y="1" z="0" angle="180"/>
@@ -224,7 +224,7 @@ def make_museum_plane_scene(spp = 16, roughness = 0.01):
             </bsdf>
 
             <shape type="obj">
-                <string name="filename" value="resources/data/obj/rectangle.obj"/>
+                <string name="filename" value="resources/data/common/meshes/rectangle.obj"/>
                 <transform name="to_world">
                     <scale x="10" y="10" z="10"/>
                     <lookat origin="0,   0, 0"
@@ -235,7 +235,7 @@ def make_museum_plane_scene(spp = 16, roughness = 0.01):
             </shape>
 
             <emitter type="envmap">
-                <string name="filename" value="resources/data/envmap/museum.exr"/>
+                <string name="filename" value="resources/data/common/textures/museum.exr"/>
                 <transform name="to_world">
                     <rotate x="0" y="0" z="1" angle="90"/>
                     <rotate x="1" y="0" z="0" angle="90"/>
@@ -279,8 +279,8 @@ SCENES = {
     },
     'museum_plane': {
         'depth':    [18.534136, 18.534126, 18.534119, 0.6803705],
-        'direct':   [0.16745913, 0.10562614, 0.077834584, 0.68026865],
-        'full':     [0.16745913, 0.10562614, 0.077834584, 0.68026865],
+        'direct':   [0.30023497, 0.18874034, 0.13849358, 0.6803551],
+        'full':     [0.30023497, 0.18874034, 0.13849358, 0.6803551],
         'factory':  make_museum_plane_scene
     },
 }


### PR DESCRIPTION
This PR adds a new XML tag `resource_path` to add path to the file resolver's list of search paths directly from an XML scene file.

Using this new feature, the `resource/data` repo became a lot cleaner, with the introduction of a `common` folder, containing meshes and textures used for testing and documentation images generation, ...