### PR TITLE
Allocate one extra triangle in Mesh buffers

### DIFF
--- a/src/librender/mesh.cpp
+++ b/src/librender/mesh.cpp
@@ -37,13 +37,13 @@ Mesh<Float, Spectrum>::Mesh(const std::string &name, ScalarSize vertex_count,
                             ScalarSize face_count, const Properties &props,
                             bool has_vertex_normals, bool has_vertex_texcoords)
     : Base(props), m_name(name), m_vertex_count(vertex_count), m_face_count(face_count) {
-
-    m_faces_buf = zero<DynamicBuffer<UInt32>>(m_face_count * 3);
-    m_vertex_positions_buf = zero<FloatStorage>(m_vertex_count * 3);
+    // Always allocate one extra triangle in the buffers
+    m_faces_buf = zero<DynamicBuffer<UInt32>>((m_face_count + 1) * 3);
+    m_vertex_positions_buf = zero<FloatStorage>((m_vertex_count + 1) * 3);
     if (has_vertex_normals)
-        m_vertex_normals_buf = zero<FloatStorage>(m_vertex_count * 3);
+        m_vertex_normals_buf = zero<FloatStorage>((m_vertex_count + 1) * 3);
     if (has_vertex_texcoords)
-        m_vertex_texcoords_buf = zero<FloatStorage>(m_vertex_count * 2);
+        m_vertex_texcoords_buf = zero<FloatStorage>((m_vertex_count + 1) * 2);
 
     m_faces_buf.managed();
     m_vertex_positions_buf.managed();

--- a/src/librender/tests/test_mesh.py
+++ b/src/librender/tests/test_mesh.py
@@ -47,11 +47,11 @@ def test02_ply_triangle(variant_scalar_rgb):
     faces = m.faces_buffer()
 
     assert not m.has_vertex_normals()
-    assert ek.slices(positions) == 9
+    assert ek.slices(positions) == 9 + 3 # always allocate one extra triangle in the buffers
     assert ek.allclose(positions[0:3], [0, 0, 0])
     assert ek.allclose(positions[3:6], [0, 0, 1])
     assert ek.allclose(positions[6:9], [0, 1, 0])
-    assert ek.slices(faces) == 3
+    assert ek.slices(faces) == 3 + 3 # always allocate one extra triangle in the buffers
     assert faces[0] == UInt32(0)
     assert faces[1] == UInt32(1)
     assert faces[2] == UInt32(2)
@@ -122,8 +122,8 @@ def test05_load_simple_mesh(variant_scalar_rgb):
         faces = shape.faces_buffer()
 
         assert shape.has_vertex_normals()
-        assert ek.slices(positions) == 72
-        assert ek.slices(faces) == 36
+        assert ek.slices(positions) == 72 + 3 # always allocate one extra triangle in the buffers
+        assert ek.slices(faces) == 36 + 3 # always allocate one extra triangle in the buffers
         assert ek.allclose(faces[6:9], [4, 5, 6])
         assert ek.allclose(positions[:5], [130, 165, 65, 82, 165])
 

--- a/src/shapes/blender.cpp
+++ b/src/shapes/blender.cpp
@@ -292,19 +292,28 @@ public:
             return;
 
         m_face_count = (ScalarSize) tmp_triangles.size();
-        m_faces_buf = DynamicBuffer<UInt32>::copy(tmp_triangles.data(), m_face_count * 3);
-
         m_vertex_count = vertex_ctr;
-        m_vertex_positions_buf = FloatStorage::copy(tmp_vertices.data(), m_vertex_count * 3);
-        m_vertex_normals_buf = FloatStorage::copy(tmp_normals.data(), m_vertex_count * 3);
+
+        // Add dummy data to trigger the allocation of one extra triangle in the buffer
+        tmp_triangles.push_back(ScalarIndex3());
+        tmp_vertices.push_back(std::array<InputFloat, 3>());
+        tmp_normals.push_back(std::array<InputFloat, 3>());
+        tmp_uvs.push_back(InputVector2f());
+        for (size_t p = 0; p < cols.size(); p++)
+            tmp_cols[p].push_back(std::array<InputFloat, 3>());
+
+        m_faces_buf = DynamicBuffer<UInt32>::copy(tmp_triangles.data(), (m_face_count + 1) * 3);
+
+        m_vertex_positions_buf = FloatStorage::copy(tmp_vertices.data(), (m_vertex_count + 1) * 3);
+        m_vertex_normals_buf = FloatStorage::copy(tmp_normals.data(), (m_vertex_count + 1) * 3);
 
         if (has_uvs)
-            m_vertex_texcoords_buf = FloatStorage::copy(tmp_uvs.data(), m_vertex_count * 2);
+            m_vertex_texcoords_buf = FloatStorage::copy(tmp_uvs.data(), (m_vertex_count + 1) * 2);
         if (has_cols) {
             for (size_t p = 0; p < cols.size(); p++) {
                 add_attribute(
                     cols[p].first, 3,
-                    FloatStorage::copy(tmp_cols[p].data(), m_vertex_count * 3));
+                    FloatStorage::copy(tmp_cols[p].data(), (m_vertex_count + 1) * 3));
             }
         }
 

--- a/src/shapes/obj.cpp
+++ b/src/shapes/obj.cpp
@@ -276,12 +276,14 @@ public:
         m_vertex_count = vertex_ctr;
         m_face_count = (ScalarSize) triangles.size();
 
-        m_faces_buf = DynamicBuffer<UInt32>::copy(triangles.data(), m_face_count * 3);
-        m_vertex_positions_buf = empty<FloatStorage>(m_vertex_count * 3);
+        // Add a dummy triangle to trigger the allocation of one extra triangle in the buffer
+        triangles.push_back(ScalarIndex3());
+        m_faces_buf = DynamicBuffer<UInt32>::copy(triangles.data(), (m_face_count + 1) * 3);
+        m_vertex_positions_buf = empty<FloatStorage>((m_vertex_count + 1) * 3);
         if (!m_disable_vertex_normals)
-            m_vertex_normals_buf = empty<FloatStorage>(m_vertex_count * 3);
+            m_vertex_normals_buf = empty<FloatStorage>((m_vertex_count + 1) * 3);
         if (!texcoords.empty())
-            m_vertex_texcoords_buf = empty<FloatStorage>(m_vertex_count * 2);
+            m_vertex_texcoords_buf = empty<FloatStorage>((m_vertex_count + 1) * 2);
 
         // TODO this is needed for the bbox(..) methods, but is it slower?
         m_faces_buf.managed();
@@ -293,8 +295,8 @@ public:
             const VertexBinding *v = &v_;
 
             while (v && v->key != ScalarIndex3{{0, 0, 0}}) {
-                InputFloat* position_ptr   = m_vertex_positions_buf.data() + v->value * 3;
-                InputFloat* normal_ptr   = m_vertex_normals_buf.data() + v->value * 3;
+                InputFloat* position_ptr = m_vertex_positions_buf.data() + v->value * 3;
+                InputFloat* normal_ptr   = m_vertex_normals_buf.data()   + v->value * 3;
                 InputFloat* texcoord_ptr = m_vertex_texcoords_buf.data() + v->value * 2;
                 auto key = v->key;
 

--- a/src/shapes/ply.cpp
+++ b/src/shapes/ply.cpp
@@ -192,14 +192,15 @@ public:
                 }
 
                 m_vertex_count = (ScalarSize) el.count;
-                m_vertex_positions_buf = empty<FloatStorage>(m_vertex_count * 3);
+                // Always allocate one extra triangle in the buffers
+                m_vertex_positions_buf = empty<FloatStorage>((m_vertex_count + 1) * 3);
                 if (!m_disable_vertex_normals)
-                    m_vertex_normals_buf = empty<FloatStorage>(m_vertex_count * 3);
+                    m_vertex_normals_buf = empty<FloatStorage>((m_vertex_count + 1) * 3);
                 if (has_vertex_texcoords)
-                    m_vertex_texcoords_buf = empty<FloatStorage>(m_vertex_count * 2);
+                    m_vertex_texcoords_buf = empty<FloatStorage>((m_vertex_count + 1) * 2);
 
                 for (auto& descr: vertex_attributes_descriptors) {
-                    descr.buf = empty<FloatStorage>(m_vertex_count * descr.dim);
+                    descr.buf = empty<FloatStorage>((m_vertex_count + 1) * descr.dim);
                     descr.buf.managed();
                 }
 
@@ -308,11 +309,12 @@ public:
                 }
 
                 m_face_count = (ScalarSize) el.count;
-                m_faces_buf = empty<DynamicBuffer<UInt32>>(m_face_count * 3);
+                // Always allocate one extra triangle in the buffers
+                m_faces_buf = empty<DynamicBuffer<UInt32>>((m_face_count + 1) * 3);
                 m_faces_buf.managed();
 
                 for (auto& descr: face_attributes_descriptors) {
-                    descr.buf = empty<FloatStorage>(m_face_count * descr.dim);
+                    descr.buf = empty<FloatStorage>((m_face_count + 1) * descr.dim);
                     descr.buf.managed();
                 }
 

--- a/src/shapes/serialized.cpp
+++ b/src/shapes/serialized.cpp
@@ -263,13 +263,14 @@ public:
         m_vertex_count = (ScalarSize) vertex_count;
         m_face_count = (ScalarSize) face_count;
 
-        m_vertex_positions_buf = empty<FloatStorage>(m_vertex_count * 3);
+        // Always allocate one extra triangle in the buffers
+        m_vertex_positions_buf = empty<FloatStorage>((m_vertex_count + 1) * 3);
         if (!m_disable_vertex_normals)
-            m_vertex_normals_buf = empty<FloatStorage>(m_vertex_count * 3);
+            m_vertex_normals_buf = empty<FloatStorage>((m_vertex_count + 1) * 3);
         if (has_flag(flags, TriMeshFlags::HasTexcoords))
-            m_vertex_texcoords_buf = empty<FloatStorage>(m_vertex_count * 2);
+            m_vertex_texcoords_buf = empty<FloatStorage>((m_vertex_count + 1) * 2);
 
-        m_faces_buf = empty<DynamicBuffer<UInt32>>(m_face_count * 3);
+        m_faces_buf = empty<DynamicBuffer<UInt32>>((m_face_count + 1) * 3);
 
         m_vertex_positions_buf.managed();
         m_vertex_normals_buf.managed();


### PR DESCRIPTION
This patch makes sure that the `Mesh` buffers allocate for one extra triangle.

This is necessary as `enoki::Array<float, 3>` is actually represented as a `enoki::Array<float, 4>` (e.g. better alignment) under the hood. This causes out of memory accessing when reading the very last triangle in the buffers (read one extra float).

Unfortunately, this could be confusing when looking at the `slices(buffer)` as it won't match `3*vertex_count` anymore. @wjakob is there another way to allocate an extra bit of memory while keeping the slice the same?