### PR TITLE
Sampler plugins

### DIFF
--- a/docs/docs_api/list_api.rst
+++ b/docs/docs_api/list_api.rst
@@ -28,6 +28,8 @@
 
 .. autoclass:: mitsuba.core.DiscreteDistribution
 
+.. autoclass:: mitsuba.core.DiscreteDistribution2D
+
 .. autoclass:: mitsuba.core.DummyStream
 
 .. autoclass:: mitsuba.core.FileResolver
@@ -342,6 +344,8 @@
 
 .. autofunction:: mitsuba.core.is_spectral
 
+.. autofunction:: mitsuba.core.luminance
+
 .. autofunction:: mitsuba.core.math.E
 
 .. autofunction:: mitsuba.core.math.Epsilon
@@ -414,6 +418,10 @@
 
 .. autofunction:: mitsuba.core.pdf_uniform_spectrum
 
+.. autofunction:: mitsuba.core.permute
+
+.. autofunction:: mitsuba.core.permute_kensler
+
 .. autofunction:: mitsuba.core.quad.composite_simpson
 
 .. autofunction:: mitsuba.core.quad.composite_simpson_38
@@ -422,7 +430,11 @@
 
 .. autofunction:: mitsuba.core.quad.gauss_lobatto
 
+.. autofunction:: mitsuba.core.radical_inverse_2
+
 .. autofunction:: mitsuba.core.sample_rgb_spectrum
+
+.. autofunction:: mitsuba.core.sample_tea_32
 
 .. autofunction:: mitsuba.core.sample_tea_float
 
@@ -435,6 +447,8 @@
 .. autofunction:: mitsuba.core.set_property
 
 .. autofunction:: mitsuba.core.set_thread_count
+
+.. autofunction:: mitsuba.core.sobol_2
 
 .. autofunction:: mitsuba.core.spline.eval_1d
 
@@ -578,6 +592,8 @@
 
 .. autoclass:: mitsuba.render.Film
 
+.. autoclass:: mitsuba.render.HitComputeFlags
+
 .. autoclass:: mitsuba.render.ImageBlock
 
 .. autoclass:: mitsuba.render.Integrator
@@ -603,6 +619,8 @@
 .. autoclass:: mitsuba.render.PhaseFunctionFlags
 
 .. autoclass:: mitsuba.render.PositionSample3f
+
+.. autoclass:: mitsuba.render.PreliminaryIntersection3f
 
 .. autoclass:: mitsuba.render.ProjectiveCamera
 

--- a/docs/examples/02_depth_integrator/depth_integrator.py
+++ b/docs/examples/02_depth_integrator/depth_integrator.py
@@ -32,7 +32,7 @@ spp = 32
 total_sample_count = ek.hprod(film_size) * spp
 
 if sampler.wavefront_size() != total_sample_count:
-    sampler.seed(ek.arange(UInt64, total_sample_count))
+    sampler.seed(0, total_sample_count)
 
 # Enumerate discrete sample & pixel indices, and uniformly sample
 # positions within each pixel.

--- a/docs/generate_plugin_doc.py
+++ b/docs/generate_plugin_doc.py
@@ -51,7 +51,11 @@ SPECTRUM_ORDERING = ['uniform',
                      'srgb_d65',
                      'blackbody']
 
-SAMPLER_ORDERING = ['independent']
+SAMPLER_ORDERING = ['independent',
+                    'stratified',
+                    'multijitter',
+                    'orthogonal',
+                    'ldsampler']
 
 INTEGRATOR_ORDERING = ['direct',
                        'path',

--- a/docs/generated/core_api.rst
+++ b/docs/generated/core_api.rst
@@ -7,8 +7,8 @@ Object
 ------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 4844
-  :end-line: 4982
+  :start-line: 4951
+  :end-line: 5089
 
 ------------
 
@@ -16,8 +16,8 @@ Properties
 ----------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 5168
-  :end-line: 5322
+  :start-line: 5275
+  :end-line: 5429
 
 ------------
 
@@ -34,20 +34,20 @@ XML
 ---
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10651
-  :end-line: 10660
+  :start-line: 10895
+  :end-line: 10904
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10661
-  :end-line: 10682
+  :start-line: 10905
+  :end-line: 10926
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10683
-  :end-line: 10692
+  :start-line: 10927
+  :end-line: 10936
 
 ------------
 
@@ -55,235 +55,103 @@ Warp
 ----
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10093
-  :end-line: 10105
+  :start-line: 10337
+  :end-line: 10349
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10106
-  :end-line: 10127
+  :start-line: 10350
+  :end-line: 10371
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10128
-  :end-line: 10137
+  :start-line: 10372
+  :end-line: 10381
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10138
-  :end-line: 10158
+  :start-line: 10382
+  :end-line: 10402
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10159
-  :end-line: 10178
+  :start-line: 10403
+  :end-line: 10422
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10179
-  :end-line: 10188
+  :start-line: 10423
+  :end-line: 10432
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10189
-  :end-line: 10204
+  :start-line: 10433
+  :end-line: 10448
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10205
-  :end-line: 10217
+  :start-line: 10449
+  :end-line: 10461
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10218
-  :end-line: 10230
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10231
-  :end-line: 10264
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10265
-  :end-line: 10284
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10285
-  :end-line: 10295
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10296
-  :end-line: 10305
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10306
-  :end-line: 10325
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10326
-  :end-line: 10344
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10345
-  :end-line: 10355
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10356
-  :end-line: 10363
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10364
-  :end-line: 10373
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10374
-  :end-line: 10383
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10384
-  :end-line: 10400
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10401
-  :end-line: 10413
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10414
-  :end-line: 10423
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10424
-  :end-line: 10433
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10434
-  :end-line: 10443
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10444
-  :end-line: 10453
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10454
-  :end-line: 10464
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10465
+  :start-line: 10462
   :end-line: 10474
 
 ------------
 
 .. include:: extracted_rst_api.rst
   :start-line: 10475
-  :end-line: 10485
+  :end-line: 10508
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10486
-  :end-line: 10495
+  :start-line: 10509
+  :end-line: 10528
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10496
-  :end-line: 10506
+  :start-line: 10529
+  :end-line: 10539
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10507
-  :end-line: 10517
+  :start-line: 10540
+  :end-line: 10549
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10518
-  :end-line: 10527
+  :start-line: 10550
+  :end-line: 10569
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10528
-  :end-line: 10541
+  :start-line: 10570
+  :end-line: 10588
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10542
-  :end-line: 10554
+  :start-line: 10589
+  :end-line: 10599
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10555
-  :end-line: 10564
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10565
-  :end-line: 10574
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10575
-  :end-line: 10587
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10588
-  :end-line: 10597
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 10598
+  :start-line: 10600
   :end-line: 10607
 
 ------------
@@ -302,13 +170,145 @@ Warp
 
 .. include:: extracted_rst_api.rst
   :start-line: 10628
-  :end-line: 10637
+  :end-line: 10644
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10638
-  :end-line: 10650
+  :start-line: 10645
+  :end-line: 10657
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10658
+  :end-line: 10667
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10668
+  :end-line: 10677
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10678
+  :end-line: 10687
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10688
+  :end-line: 10697
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10698
+  :end-line: 10708
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10709
+  :end-line: 10718
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10719
+  :end-line: 10729
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10730
+  :end-line: 10739
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10740
+  :end-line: 10750
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10751
+  :end-line: 10761
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10762
+  :end-line: 10771
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10772
+  :end-line: 10785
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10786
+  :end-line: 10798
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10799
+  :end-line: 10808
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10809
+  :end-line: 10818
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10819
+  :end-line: 10831
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10832
+  :end-line: 10841
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10842
+  :end-line: 10851
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10852
+  :end-line: 10861
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10862
+  :end-line: 10871
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10872
+  :end-line: 10881
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10882
+  :end-line: 10894
 
 ------------
 
@@ -328,80 +328,80 @@ Distributions
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 2993
-  :end-line: 3182
+  :start-line: 3028
+  :end-line: 3217
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 2517
-  :end-line: 2635
+  :start-line: 2552
+  :end-line: 2670
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 2636
-  :end-line: 2754
+  :start-line: 2671
+  :end-line: 2789
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 2755
-  :end-line: 2873
+  :start-line: 2790
+  :end-line: 2908
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 2874
-  :end-line: 2992
+  :start-line: 2909
+  :end-line: 3027
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3413
-  :end-line: 3528
+  :start-line: 3448
+  :end-line: 3572
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3529
-  :end-line: 3644
+  :start-line: 3573
+  :end-line: 3697
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3645
-  :end-line: 3760
+  :start-line: 3698
+  :end-line: 3822
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3761
-  :end-line: 3876
+  :start-line: 3823
+  :end-line: 3947
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3877
-  :end-line: 3992
+  :start-line: 3948
+  :end-line: 4072
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3993
-  :end-line: 4108
+  :start-line: 4073
+  :end-line: 4197
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 4109
-  :end-line: 4224
+  :start-line: 4198
+  :end-line: 4322
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 4225
-  :end-line: 4340
+  :start-line: 4323
+  :end-line: 4447
 
 ------------
 
@@ -409,260 +409,260 @@ Math
 ----
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8955
-  :end-line: 8958
+  :start-line: 9087
+  :end-line: 9090
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8959
-  :end-line: 8962
+  :start-line: 9091
+  :end-line: 9094
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8963
-  :end-line: 8966
+  :start-line: 9095
+  :end-line: 9098
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8967
-  :end-line: 8970
+  :start-line: 9099
+  :end-line: 9102
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8971
-  :end-line: 8974
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 8975
-  :end-line: 8978
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 8979
-  :end-line: 8982
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 8983
-  :end-line: 8986
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 8987
-  :end-line: 8990
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 8991
-  :end-line: 8994
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 8995
-  :end-line: 8998
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 8999
-  :end-line: 9002
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 9003
-  :end-line: 9006
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 9007
-  :end-line: 9010
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 9011
-  :end-line: 9014
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 9015
-  :end-line: 9018
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 9019
-  :end-line: 9022
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 9023
-  :end-line: 9026
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 9027
-  :end-line: 9030
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 9031
-  :end-line: 9064
-
-------------
-
-.. include:: extracted_rst_api.rst
-  :start-line: 9065
+  :start-line: 9103
   :end-line: 9106
 
 ------------
 
 .. include:: extracted_rst_api.rst
   :start-line: 9107
-  :end-line: 9116
+  :end-line: 9110
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9117
-  :end-line: 9148
+  :start-line: 9111
+  :end-line: 9114
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9149
+  :start-line: 9115
+  :end-line: 9118
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 9119
+  :end-line: 9122
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 9123
+  :end-line: 9126
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 9127
+  :end-line: 9130
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 9131
+  :end-line: 9134
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 9135
+  :end-line: 9138
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 9139
+  :end-line: 9142
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 9143
+  :end-line: 9146
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 9147
+  :end-line: 9150
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 9151
+  :end-line: 9154
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 9155
+  :end-line: 9158
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 9159
   :end-line: 9162
 
 ------------
 
 .. include:: extracted_rst_api.rst
   :start-line: 9163
-  :end-line: 9175
+  :end-line: 9196
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9176
-  :end-line: 9185
+  :start-line: 9197
+  :end-line: 9238
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9186
-  :end-line: 9193
+  :start-line: 9239
+  :end-line: 9248
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9194
-  :end-line: 9201
+  :start-line: 9249
+  :end-line: 9280
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9202
-  :end-line: 9209
+  :start-line: 9281
+  :end-line: 9294
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9210
-  :end-line: 9217
+  :start-line: 9295
+  :end-line: 9307
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9218
-  :end-line: 9227
+  :start-line: 9308
+  :end-line: 9317
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9228
-  :end-line: 9243
+  :start-line: 9318
+  :end-line: 9325
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9244
-  :end-line: 9253
+  :start-line: 9326
+  :end-line: 9333
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9254
-  :end-line: 9267
+  :start-line: 9334
+  :end-line: 9341
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9546
-  :end-line: 9629
+  :start-line: 9342
+  :end-line: 9349
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9630
-  :end-line: 9680
+  :start-line: 9350
+  :end-line: 9359
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9681
-  :end-line: 9704
+  :start-line: 9360
+  :end-line: 9375
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9705
-  :end-line: 9728
+  :start-line: 9376
+  :end-line: 9385
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9729
-  :end-line: 9752
+  :start-line: 9386
+  :end-line: 9399
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9753
-  :end-line: 9832
+  :start-line: 9790
+  :end-line: 9873
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9833
-  :end-line: 9900
+  :start-line: 9874
+  :end-line: 9924
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9901
-  :end-line: 9959
+  :start-line: 9925
+  :end-line: 9948
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9960
-  :end-line: 10029
+  :start-line: 9949
+  :end-line: 9972
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 9973
+  :end-line: 9996
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 9997
+  :end-line: 10076
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10077
+  :end-line: 10144
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10145
+  :end-line: 10203
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10204
+  :end-line: 10273
 
 ------------
 
@@ -670,14 +670,14 @@ Log
 ---
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3194
-  :end-line: 3225
+  :start-line: 3229
+  :end-line: 3260
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3226
-  :end-line: 3376
+  :start-line: 3261
+  :end-line: 3411
 
 ------------
 
@@ -691,92 +691,92 @@ Types
 -----
 
 .. include:: extracted_rst_api.rst
-  :start-line: 7340
-  :end-line: 7439
+  :start-line: 7447
+  :end-line: 7546
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 7440
-  :end-line: 7539
+  :start-line: 7547
+  :end-line: 7646
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 7540
-  :end-line: 7639
+  :start-line: 7647
+  :end-line: 7746
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 7640
-  :end-line: 7739
+  :start-line: 7747
+  :end-line: 7846
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 7740
-  :end-line: 7839
+  :start-line: 7847
+  :end-line: 7946
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 7840
-  :end-line: 7939
+  :start-line: 7947
+  :end-line: 8046
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 7940
-  :end-line: 8044
+  :start-line: 8047
+  :end-line: 8151
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8045
-  :end-line: 8149
+  :start-line: 8152
+  :end-line: 8256
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8150
-  :end-line: 8254
+  :start-line: 8257
+  :end-line: 8361
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8255
-  :end-line: 8362
+  :start-line: 8362
+  :end-line: 8469
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8363
-  :end-line: 8470
+  :start-line: 8470
+  :end-line: 8577
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8471
-  :end-line: 8578
+  :start-line: 8578
+  :end-line: 8685
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 4341
-  :end-line: 4430
+  :start-line: 4448
+  :end-line: 4537
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 4431
-  :end-line: 4538
+  :start-line: 4538
+  :end-line: 4645
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 4539
-  :end-line: 4711
+  :start-line: 4646
+  :end-line: 4818
 
 ------------
 
@@ -799,14 +799,14 @@ Types
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 6969
-  :end-line: 7102
+  :start-line: 7076
+  :end-line: 7209
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 7103
-  :end-line: 7329
+  :start-line: 7210
+  :end-line: 7436
 
 ------------
 
@@ -851,481 +851,523 @@ Other
 
 .. include:: extracted_rst_api.rst
   :start-line: 2107
-  :end-line: 2118
+  :end-line: 2141
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 2119
-  :end-line: 2178
+  :start-line: 2142
+  :end-line: 2153
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 2179
-  :end-line: 2233
+  :start-line: 2154
+  :end-line: 2213
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 2234
-  :end-line: 2271
+  :start-line: 2214
+  :end-line: 2268
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 2272
-  :end-line: 2309
+  :start-line: 2269
+  :end-line: 2306
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 2310
-  :end-line: 2516
+  :start-line: 2307
+  :end-line: 2344
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3183
-  :end-line: 3193
+  :start-line: 2345
+  :end-line: 2551
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3377
-  :end-line: 3380
+  :start-line: 3218
+  :end-line: 3228
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3381
-  :end-line: 3384
+  :start-line: 3412
+  :end-line: 3415
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3385
-  :end-line: 3388
+  :start-line: 3416
+  :end-line: 3419
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3389
-  :end-line: 3392
+  :start-line: 3420
+  :end-line: 3423
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3393
-  :end-line: 3396
+  :start-line: 3424
+  :end-line: 3427
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3397
-  :end-line: 3400
+  :start-line: 3428
+  :end-line: 3431
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3401
-  :end-line: 3404
+  :start-line: 3432
+  :end-line: 3435
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3405
-  :end-line: 3408
+  :start-line: 3436
+  :end-line: 3439
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 3409
-  :end-line: 3412
+  :start-line: 3440
+  :end-line: 3443
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 4712
-  :end-line: 4808
+  :start-line: 3444
+  :end-line: 3447
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 4809
-  :end-line: 4843
+  :start-line: 4819
+  :end-line: 4915
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 4983
-  :end-line: 5136
+  :start-line: 4916
+  :end-line: 4950
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 5137
-  :end-line: 5167
+  :start-line: 5090
+  :end-line: 5243
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 5323
-  :end-line: 5430
+  :start-line: 5244
+  :end-line: 5274
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 5431
-  :end-line: 5553
+  :start-line: 5430
+  :end-line: 5537
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 5554
-  :end-line: 5590
+  :start-line: 5538
+  :end-line: 5660
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 5591
-  :end-line: 5646
+  :start-line: 5661
+  :end-line: 5697
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 5647
-  :end-line: 5761
+  :start-line: 5698
+  :end-line: 5753
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 5762
-  :end-line: 5772
+  :start-line: 5754
+  :end-line: 5868
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 5773
-  :end-line: 6272
+  :start-line: 5869
+  :end-line: 5879
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 6273
-  :end-line: 6304
+  :start-line: 5880
+  :end-line: 6379
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 6305
-  :end-line: 6619
+  :start-line: 6380
+  :end-line: 6411
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 6620
-  :end-line: 6716
+  :start-line: 6412
+  :end-line: 6726
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 6717
-  :end-line: 6960
+  :start-line: 6727
+  :end-line: 6823
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 6961
-  :end-line: 6968
+  :start-line: 6824
+  :end-line: 7067
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 7330
-  :end-line: 7331
+  :start-line: 7068
+  :end-line: 7075
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 7332
-  :end-line: 7335
+  :start-line: 7437
+  :end-line: 7438
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 7336
-  :end-line: 7339
+  :start-line: 7439
+  :end-line: 7442
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8579
-  :end-line: 8628
+  :start-line: 7443
+  :end-line: 7446
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8629
-  :end-line: 8639
+  :start-line: 8686
+  :end-line: 8735
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8640
-  :end-line: 8650
+  :start-line: 8736
+  :end-line: 8746
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8651
-  :end-line: 8661
+  :start-line: 8747
+  :end-line: 8757
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8662
-  :end-line: 8672
+  :start-line: 8758
+  :end-line: 8768
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8673
-  :end-line: 8682
+  :start-line: 8769
+  :end-line: 8779
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8683
-  :end-line: 8690
+  :start-line: 8780
+  :end-line: 8789
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8691
-  :end-line: 8704
+  :start-line: 8790
+  :end-line: 8797
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8705
-  :end-line: 8717
+  :start-line: 8798
+  :end-line: 8811
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8718
-  :end-line: 8724
+  :start-line: 8812
+  :end-line: 8824
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8725
-  :end-line: 8739
+  :start-line: 8825
+  :end-line: 8831
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8740
-  :end-line: 8749
+  :start-line: 8832
+  :end-line: 8846
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8750
-  :end-line: 8761
+  :start-line: 8847
+  :end-line: 8856
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8762
-  :end-line: 8771
+  :start-line: 8857
+  :end-line: 8868
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8772
-  :end-line: 8782
+  :start-line: 8869
+  :end-line: 8878
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8783
-  :end-line: 8890
+  :start-line: 8879
+  :end-line: 8889
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8891
-  :end-line: 8894
+  :start-line: 8890
+  :end-line: 8997
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8895
-  :end-line: 8905
+  :start-line: 8998
+  :end-line: 9001
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8906
-  :end-line: 8920
+  :start-line: 9002
+  :end-line: 9012
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8921
-  :end-line: 8924
+  :start-line: 9013
+  :end-line: 9027
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8925
-  :end-line: 8938
+  :start-line: 9028
+  :end-line: 9031
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8939
-  :end-line: 8942
+  :start-line: 9032
+  :end-line: 9045
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8943
-  :end-line: 8946
+  :start-line: 9046
+  :end-line: 9049
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8947
-  :end-line: 8950
+  :start-line: 9050
+  :end-line: 9053
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 8951
-  :end-line: 8954
+  :start-line: 9054
+  :end-line: 9057
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9268
-  :end-line: 9296
+  :start-line: 9058
+  :end-line: 9061
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9297
-  :end-line: 9315
+  :start-line: 9062
+  :end-line: 9086
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9316
-  :end-line: 9333
+  :start-line: 9400
+  :end-line: 9428
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9334
-  :end-line: 9351
+  :start-line: 9429
+  :end-line: 9447
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9352
-  :end-line: 9372
+  :start-line: 9448
+  :end-line: 9475
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9373
-  :end-line: 9396
+  :start-line: 9476
+  :end-line: 9511
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9397
-  :end-line: 9431
+  :start-line: 9512
+  :end-line: 9529
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9432
-  :end-line: 9456
+  :start-line: 9530
+  :end-line: 9547
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9457
-  :end-line: 9479
+  :start-line: 9548
+  :end-line: 9568
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9480
-  :end-line: 9502
+  :start-line: 9569
+  :end-line: 9592
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9503
-  :end-line: 9521
+  :start-line: 9593
+  :end-line: 9605
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9522
-  :end-line: 9535
+  :start-line: 9606
+  :end-line: 9640
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 9536
-  :end-line: 9545
+  :start-line: 9641
+  :end-line: 9662
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10030
-  :end-line: 10042
+  :start-line: 9663
+  :end-line: 9687
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10043
-  :end-line: 10050
+  :start-line: 9688
+  :end-line: 9710
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10051
-  :end-line: 10057
+  :start-line: 9711
+  :end-line: 9733
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10058
-  :end-line: 10070
+  :start-line: 9734
+  :end-line: 9752
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10071
-  :end-line: 10084
+  :start-line: 9753
+  :end-line: 9766
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10085
-  :end-line: 10092
+  :start-line: 9767
+  :end-line: 9776
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10693
-  :end-line: 10705
+  :start-line: 9777
+  :end-line: 9789
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10274
+  :end-line: 10286
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10287
+  :end-line: 10294
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10295
+  :end-line: 10301
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10302
+  :end-line: 10314
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10315
+  :end-line: 10328
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10329
+  :end-line: 10336
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 10937
+  :end-line: 10949
 
 ------------
 

--- a/docs/generated/extracted_rst_api.rst
+++ b/docs/generated/extracted_rst_api.rst
@@ -2105,6 +2105,41 @@
         Returns → None:
             *no description available*
 
+.. py:class:: mitsuba.core.DiscreteDistribution2D
+
+    .. py:method:: mitsuba.core.DiscreteDistribution2D.eval(self, pos, active=True)
+
+        Parameter ``pos`` (enoki.scalar.Vector2u):
+            *no description available*
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → float:
+            *no description available*
+
+    .. py:method:: mitsuba.core.DiscreteDistribution2D.pdf(self, pos, active=True)
+
+        Parameter ``pos`` (enoki.scalar.Vector2u):
+            *no description available*
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → float:
+            *no description available*
+
+    .. py:method:: mitsuba.core.DiscreteDistribution2D.sample(self, sample, active=True)
+
+        Parameter ``sample`` (enoki.scalar.Vector2f):
+            *no description available*
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → Tuple[enoki.scalar.Vector2u, float, enoki.scalar.Vector2f]:
+            *no description available*
+
 .. py:class:: mitsuba.core.DummyStream
 
     Base class: :py:obj:`mitsuba.core.Stream`
@@ -3385,7 +3420,7 @@
 
 .. py:data:: mitsuba.core.MTS_ENABLE_OPTIX
     :type: bool
-    :value: False
+    :value: True
 
 .. py:data:: mitsuba.core.MTS_FILTER_RESOLUTION
     :type: int
@@ -3437,6 +3472,15 @@
     the distribution is discretized. Linear interpolation is used when
     sampling or evaluating the distribution for in-between parameter
     values.
+
+    There are two variants of ``Marginal2D:`` when ``Continuous=false``,
+    discrete marginal/conditional distributions are used to select a
+    bilinear bilinear patch, followed by a continuous sampling step that
+    chooses a specific position inside the patch. When
+    ``Continuous=true``, continuous marginal/conditional distributions are
+    used instead, and the second step is no longer needed. The latter
+    scheme requires more computation and memory accesses but produces an
+    overall smoother mapping.
 
     Remark:
         The Python API exposes explicitly instantiated versions of this
@@ -3554,6 +3598,15 @@
     sampling or evaluating the distribution for in-between parameter
     values.
 
+    There are two variants of ``Marginal2D:`` when ``Continuous=false``,
+    discrete marginal/conditional distributions are used to select a
+    bilinear bilinear patch, followed by a continuous sampling step that
+    chooses a specific position inside the patch. When
+    ``Continuous=true``, continuous marginal/conditional distributions are
+    used instead, and the second step is no longer needed. The latter
+    scheme requires more computation and memory accesses but produces an
+    overall smoother mapping.
+
     Remark:
         The Python API exposes explicitly instantiated versions of this
         class named ``MarginalDiscrete2D0`` to ``MarginalDiscrete2D3`` and
@@ -3669,6 +3722,15 @@
     the distribution is discretized. Linear interpolation is used when
     sampling or evaluating the distribution for in-between parameter
     values.
+
+    There are two variants of ``Marginal2D:`` when ``Continuous=false``,
+    discrete marginal/conditional distributions are used to select a
+    bilinear bilinear patch, followed by a continuous sampling step that
+    chooses a specific position inside the patch. When
+    ``Continuous=true``, continuous marginal/conditional distributions are
+    used instead, and the second step is no longer needed. The latter
+    scheme requires more computation and memory accesses but produces an
+    overall smoother mapping.
 
     Remark:
         The Python API exposes explicitly instantiated versions of this
@@ -3786,6 +3848,15 @@
     sampling or evaluating the distribution for in-between parameter
     values.
 
+    There are two variants of ``Marginal2D:`` when ``Continuous=false``,
+    discrete marginal/conditional distributions are used to select a
+    bilinear bilinear patch, followed by a continuous sampling step that
+    chooses a specific position inside the patch. When
+    ``Continuous=true``, continuous marginal/conditional distributions are
+    used instead, and the second step is no longer needed. The latter
+    scheme requires more computation and memory accesses but produces an
+    overall smoother mapping.
+
     Remark:
         The Python API exposes explicitly instantiated versions of this
         class named ``MarginalDiscrete2D0`` to ``MarginalDiscrete2D3`` and
@@ -3901,6 +3972,15 @@
     the distribution is discretized. Linear interpolation is used when
     sampling or evaluating the distribution for in-between parameter
     values.
+
+    There are two variants of ``Marginal2D:`` when ``Continuous=false``,
+    discrete marginal/conditional distributions are used to select a
+    bilinear bilinear patch, followed by a continuous sampling step that
+    chooses a specific position inside the patch. When
+    ``Continuous=true``, continuous marginal/conditional distributions are
+    used instead, and the second step is no longer needed. The latter
+    scheme requires more computation and memory accesses but produces an
+    overall smoother mapping.
 
     Remark:
         The Python API exposes explicitly instantiated versions of this
@@ -4018,6 +4098,15 @@
     sampling or evaluating the distribution for in-between parameter
     values.
 
+    There are two variants of ``Marginal2D:`` when ``Continuous=false``,
+    discrete marginal/conditional distributions are used to select a
+    bilinear bilinear patch, followed by a continuous sampling step that
+    chooses a specific position inside the patch. When
+    ``Continuous=true``, continuous marginal/conditional distributions are
+    used instead, and the second step is no longer needed. The latter
+    scheme requires more computation and memory accesses but produces an
+    overall smoother mapping.
+
     Remark:
         The Python API exposes explicitly instantiated versions of this
         class named ``MarginalDiscrete2D0`` to ``MarginalDiscrete2D3`` and
@@ -4134,6 +4223,15 @@
     sampling or evaluating the distribution for in-between parameter
     values.
 
+    There are two variants of ``Marginal2D:`` when ``Continuous=false``,
+    discrete marginal/conditional distributions are used to select a
+    bilinear bilinear patch, followed by a continuous sampling step that
+    chooses a specific position inside the patch. When
+    ``Continuous=true``, continuous marginal/conditional distributions are
+    used instead, and the second step is no longer needed. The latter
+    scheme requires more computation and memory accesses but produces an
+    overall smoother mapping.
+
     Remark:
         The Python API exposes explicitly instantiated versions of this
         class named ``MarginalDiscrete2D0`` to ``MarginalDiscrete2D3`` and
@@ -4249,6 +4347,15 @@
     the distribution is discretized. Linear interpolation is used when
     sampling or evaluating the distribution for in-between parameter
     values.
+
+    There are two variants of ``Marginal2D:`` when ``Continuous=false``,
+    discrete marginal/conditional distributions are used to select a
+    bilinear bilinear patch, followed by a continuous sampling step that
+    chooses a specific position inside the patch. When
+    ``Continuous=true``, continuous marginal/conditional distributions are
+    used instead, and the second step is no longer needed. The latter
+    scheme requires more computation and memory accesses but produces an
+    overall smoother mapping.
 
     Remark:
         The Python API exposes explicitly instantiated versions of this
@@ -8953,6 +9060,31 @@
     :type: bool
     :value: False
 
+.. py:function:: mitsuba.core.luminance(overloaded)
+
+
+    .. py:function:: luminance(value, wavelengths, active=True)
+
+        Parameter ``value`` (enoki.scalar.Vector3f):
+            *no description available*
+
+        Parameter ``wavelengths`` (enoki.scalar.Vector3f):
+            *no description available*
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → float:
+            *no description available*
+
+    .. py:function:: luminance(c)
+
+        Parameter ``c`` (enoki.scalar.Vector3f):
+            *no description available*
+
+        Returns → float:
+            *no description available*
+
 .. py:data:: mitsuba.core.math.E
     :type: float
     :value: 2.7182817459106445
@@ -9314,6 +9446,70 @@
         Returns → enoki.scalar.Vector3f:
             *no description available*
 
+.. py:function:: mitsuba.core.permute(value, sample_count, seed, rounds=4)
+
+    Generate pseudorandom permutation vector using a shuffling network and
+    the sample_tea function. This algorithm has a O(log2(sample_count))
+    complexity but only supports permutation vectors whose lengths are a
+    power of 2.
+
+    Parameter ``index``:
+        Input index to be mapped
+
+    Parameter ``sample_count`` (int):
+        Length of the permutation vector
+
+    Parameter ``seed`` (int):
+        Seed value used as second input to the Tiny Encryption Algorithm.
+        Can be used to generate different permutation vectors.
+
+    Parameter ``rounds`` (int):
+        How many rounds should be executed by the Tiny Encryption
+        Algorithm? The default is 2.
+
+    Parameter ``value`` (int):
+        *no description available*
+
+    Returns → int:
+        The index corresponding to the input index in the pseudorandom
+        permutation vector.
+
+.. py:function:: mitsuba.core.permute_kensler(i, l, p, active=True)
+
+    Generate pseudorandom permutation vector using the algorithm described
+    in Pixar's technical memo "Correlated Multi-Jittered Sampling":
+
+    https://graphics.pixar.com/library/MultiJitteredSampling/
+
+    Unlike permute, this function supports permutation vectors of any
+    length.
+
+    Parameter ``index``:
+        Input index to be mapped
+
+    Parameter ``sample_count``:
+        Length of the permutation vector
+
+    Parameter ``seed``:
+        Seed value used as second input to the Tiny Encryption Algorithm.
+        Can be used to generate different permutation vectors.
+
+    Parameter ``i`` (int):
+        *no description available*
+
+    Parameter ``l`` (int):
+        *no description available*
+
+    Parameter ``p`` (int):
+        *no description available*
+
+    Parameter ``active`` (bool):
+        Mask to specify active lanes.
+
+    Returns → int:
+        The index corresponding to the input index in the pseudorandom
+        permutation vector.
+
 .. py:function:: mitsuba.core.quad.composite_simpson(n)
 
     Computes the nodes and weights of a composite Simpson quadrature rule
@@ -9395,6 +9591,19 @@
         A tuple (nodes, weights) storing the nodes and weights of the
         quadrature rule.
 
+.. py:function:: mitsuba.core.radical_inverse_2(index, scramble)
+
+    Van der Corput radical inverse in base 2
+
+    Parameter ``index`` (int):
+        *no description available*
+
+    Parameter ``scramble`` (int):
+        *no description available*
+
+    Returns → float:
+        *no description available*
+
 .. py:function:: mitsuba.core.sample_rgb_spectrum(overloaded)
 
 
@@ -9429,6 +9638,28 @@
 
         Returns → Tuple[enoki.scalar.Vector3f, enoki.scalar.Vector3f]:
             *no description available*
+
+.. py:function:: mitsuba.core.sample_tea_32(v0, v1, rounds=4)
+
+    Generate fast and reasonably good pseudorandom numbers using the Tiny
+    Encryption Algorithm (TEA) by David Wheeler and Roger Needham.
+
+    For details, refer to "GPU Random Numbers via the Tiny Encryption
+    Algorithm" by Fahad Zafar, Marc Olano, and Aaron Curtis.
+
+    Parameter ``v0`` (int):
+        First input value to be encrypted (could be the sample index)
+
+    Parameter ``v1`` (int):
+        Second input value to be encrypted (e.g. the requested random
+        number dimension)
+
+    Parameter ``rounds`` (int):
+        How many rounds should be executed? The default for random number
+        generation is 4.
+
+    Returns → int:
+        A uniformly distributed 32-bit integer
 
 .. py:function:: mitsuba.core.sample_tea_float
 
@@ -9542,6 +9773,19 @@
         *no description available*
 
     Returns → None:
+        *no description available*
+
+.. py:function:: mitsuba.core.sobol_2(index, scramble)
+
+    Sobol' radical inverse in base 2
+
+    Parameter ``index`` (int):
+        *no description available*
+
+    Parameter ``scramble`` (int):
+        *no description available*
+
+    Returns → float:
         *no description available*
 
 .. py:function:: mitsuba.core.spline.eval_1d(overloaded)
@@ -11675,6 +11919,57 @@
         Returns → enoki.scalar.Vector2i:
             *no description available*
 
+.. py:class:: mitsuba.render.HitComputeFlags
+
+    Members:
+
+    .. py:data:: None
+
+        No flags set
+
+    .. py:data:: Minimal
+
+        Compute position and geometric normal
+
+    .. py:data:: UV
+
+        Compute UV coordinates
+
+    .. py:data:: dPdUV
+
+        Compute position partials wrt. UV coordinates
+
+    .. py:data:: dNGdUV
+
+        Compute the geometric normal partials wrt. the UV coordinates
+
+    .. py:data:: dNSdUV
+
+        Compute the shading normal partials wrt. the UV coordinates
+
+    .. py:data:: ShadingFrame
+
+        Compute shading normal and shading frame
+
+    .. py:data:: NonDifferentiable
+
+        Force computed fields to not be be differentiable
+
+    .. py:data:: All
+
+        Compute all fields of the surface interaction data structure (default)
+
+    .. py:data:: AllNonDifferentiable
+
+        Compute all fields of the surface interaction data structure in a non
+        differentiable way
+
+    .. py:method:: __init__(self, arg0)
+
+        Parameter ``arg0`` (int):
+            *no description available*
+
+
 .. py:class:: mitsuba.render.ImageBlock
 
     Base class: :py:obj:`mitsuba.core.Object`
@@ -12150,6 +12445,17 @@
         Returns → enoki.dynamic.Float32:
             *no description available*
 
+    .. py:method:: mitsuba.render.Mesh.eval_parameterization(self, uv, active=True)
+
+        Parameter ``uv`` (enoki.scalar.Vector2f):
+            *no description available*
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → :py:obj:`mitsuba.render.SurfaceInteraction3f`:
+            *no description available*
+
     .. py:method:: mitsuba.render.Mesh.face_count(self)
 
         Return the total number of faces
@@ -12194,7 +12500,7 @@
         Parameter ``active`` (bool):
             Mask to specify active lanes.
 
-        Returns → Tuple[bool, float, float, float]:
+        Returns → :py:obj:`mitsuba.render.PreliminaryIntersection3f`:
             Returns an ordered tuple ``(mask, u, v, t)``, where ``mask``
             indicates whether an intersection was found, ``t`` contains the
             distance from the ray origin to the intersection point, and ``u``
@@ -12598,7 +12904,7 @@
 
     .. py:data:: None
 
-        No flags set (default value)
+        
 
     .. py:data:: Isotropic
 
@@ -12711,6 +13017,76 @@
         Returns → :py:obj:`mitsuba.render.PositionSample3f`:
             *no description available*
 
+.. py:class:: mitsuba.render.PreliminaryIntersection3f
+
+    Stores preliminary information related to a ray intersection
+
+    This data structure is used as return type for the
+    Shape::ray_intersect_preliminary efficient ray intersection routine.
+    It stores whether the shape is intersected by a given ray, and cache
+    preliminary information about the intersection if that is the case.
+
+    If the intersection is deemed relevant, detailed intersection
+    information can later be obtained via the create_surface_interaction()
+    method.
+
+    .. py:method:: __init__(self)
+
+
+    .. py:method:: mitsuba.render.PreliminaryIntersection3f.compute_surface_interaction(self, ray, flags=HitComputeFlags.All, active=True)
+
+        Compute and return detailed information related to a surface
+        interaction
+
+        Parameter ``ray`` (:py:obj:`mitsuba.core.Ray3f`):
+            Ray associated with the ray intersection
+
+        Parameter ``flags`` (:py:obj:`mitsuba.render.HitComputeFlags`):
+            Flags specifying which information should be computed
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → :py:obj:`mitsuba.render.SurfaceInteraction3f`:
+            A data structure containing the detailed information
+
+    .. py:method:: mitsuba.render.PreliminaryIntersection3f.instance
+        :property:
+
+        Stores a pointer to the parent instance (if applicable)
+
+    .. py:method:: mitsuba.render.PreliminaryIntersection3f.is_valid(self)
+
+        Is the current interaction valid?
+
+        Returns → bool:
+            *no description available*
+
+    .. py:method:: mitsuba.render.PreliminaryIntersection3f.prim_index
+        :property:
+
+        Primitive index, e.g. the triangle ID (if applicable)
+
+    .. py:method:: mitsuba.render.PreliminaryIntersection3f.prim_uv
+        :property:
+
+        2D coordinates on the primitive surface parameterization
+
+    .. py:method:: mitsuba.render.PreliminaryIntersection3f.shape
+        :property:
+
+        Pointer to the associated shape
+
+    .. py:method:: mitsuba.render.PreliminaryIntersection3f.shape_index
+        :property:
+
+        Shape index, e.g. the shape ID in shapegroup (if applicable)
+
+    .. py:method:: mitsuba.render.PreliminaryIntersection3f.t
+        :property:
+
+        Distance traveled along the ray
+
 .. py:class:: mitsuba.render.ProjectiveCamera
 
     Base class: :py:obj:`mitsuba.render.Sensor`
@@ -12752,6 +13128,53 @@
 .. py:class:: mitsuba.render.Sampler
 
     Base class: :py:obj:`mitsuba.core.Object`
+
+    Base class of all sample generators.
+
+    For each sample in a pixel, a sample generator produces a
+    (hypothetical) point in the infinite dimensional random number cube. A
+    rendering algorithm can then request subsequent 1D or 2D components of
+    this point using the ``next_1d`` and ``next_2d`` functions.
+
+    Scalar and wavefront rendering algorithms will need interact with the
+    sampler interface in a slightly different way:
+
+    Scalar rendering algorithm:
+
+    1. Before beginning to render a pixel block, the rendering algorithm
+    calls ``seed`` to initialize a new sequence with the specific seed
+    offset. 2. The first pixel sample can now be computed, after which
+    ``advance`` needs to be invoked. This repeats until all pixel samples
+    have been generated. Note that some implementations need to be
+    configured for a certain number of pixel samples, and exceeding these
+    will lead to an exception being thrown. 3. While computing a pixel
+    sample, the rendering algorithm usually requests batches of (pseudo-)
+    random numbers using the ``next_1d`` and ``next_2d`` functions before
+    moving on to the next sample.
+
+    Wavefront rendering algorithm:
+
+    1. Before beginning to render the wavefront, the rendering algorithm
+    needs to inform the sampler of the amount of samples rendered in
+    parallel for every pixel in the wavefront. This can be achieved by
+    calling ``set_samples_per_wavefront`` . 2. Then the rendering
+    algorithm should seed the sampler and set the appropriate wavefront
+    size by calling ``seed``. A different seed value, based on the
+    ``base_seed`` and the seed offset, will be used for every sample (of
+    every pixel) in the wavefront. 3. ``advance`` can be used to advance
+    to the next sample in the sequence. 4. As in the scalar approach, the
+    rendering algorithm can request batches of (pseudo-) random numbers
+    using the ``next_1d`` and ``next_2d`` functions.
+
+    .. py:method:: mitsuba.render.Sampler.advance(self)
+
+        Advance to the next sample.
+
+        A subsequent call to ``next_1d`` or ``next_2d`` will access the first
+        1D or 2D components of this sample.
+
+        Returns → None:
+            *no description available*
 
     .. py:method:: mitsuba.render.Sampler.clone(self)
 
@@ -12795,15 +13218,28 @@
         Returns → int:
             *no description available*
 
-    .. py:method:: mitsuba.render.Sampler.seed(self, seed_value)
+    .. py:method:: mitsuba.render.Sampler.seed(self, seed_offset, wavefront_size=1)
 
         Deterministically seed the underlying RNG, if applicable.
 
         In the context of wavefront ray tracing & dynamic arrays, this
-        function must be called with a ``seed_value`` matching the size of the
-        wavefront.
+        function must be called with ``wavefront_size`` matching the size of
+        the wavefront.
 
-        Parameter ``seed_value`` (int):
+        Parameter ``seed_offset`` (int):
+            *no description available*
+
+        Parameter ``wavefront_size`` (int):
+            *no description available*
+
+        Returns → None:
+            *no description available*
+
+    .. py:method:: mitsuba.render.Sampler.set_samples_per_wavefront(self, samples_per_wavefront)
+
+        Set the number of samples per pass in wavefront modes (default is 1)
+
+        Parameter ``samples_per_wavefront`` (int):
             *no description available*
 
         Returns → None:
@@ -12939,22 +13375,45 @@
         Returns → float:
             *no description available*
 
-    .. py:method:: mitsuba.render.Scene.ray_intersect(self, ray, active=True)
+    .. py:method:: mitsuba.render.Scene.ray_intersect(overloaded)
 
-        Intersect a ray against all primitives stored in the scene and return
-        information about the resulting surface interaction
 
-        Parameter ``ray`` (:py:obj:`mitsuba.core.Ray3f`):
-            A 3-dimensional ray data structure with minimum/maximum extent
-            information, as well as a time value (which matters when the
-            shapes are in motion)
+        .. py:method:: ray_intersect(self, ray, active=True)
 
-        Parameter ``active`` (bool):
-            Mask to specify active lanes.
+            Intersect a ray against all primitives stored in the scene and return
+            information about the resulting surface interaction
 
-        Returns → :py:obj:`mitsuba.render.SurfaceInteraction`:
-            A detailed surface interaction record. Query its ``is_valid()``
-            method to determine whether an intersection was actually found.
+            Parameter ``ray`` (:py:obj:`mitsuba.core.Ray3f`):
+                A 3-dimensional ray data structure with minimum/maximum extent
+                information, as well as a time value (which matters when the
+                shapes are in motion)
+
+            Returns → :py:obj:`mitsuba.render.SurfaceInteraction`:
+                A detailed surface interaction record. Query its ``is_valid()``
+                method to determine whether an intersection was actually found.
+
+            Parameter ``active`` (bool):
+                Mask to specify active lanes.
+
+        .. py:method:: ray_intersect(self, ray, flags, active=True)
+
+            Intersect a ray against all primitives stored in the scene and return
+            information about the resulting surface interaction
+
+            Parameter ``ray`` (:py:obj:`mitsuba.core.Ray3f`):
+                A 3-dimensional ray data structure with minimum/maximum extent
+                information, as well as a time value (which matters when the
+                shapes are in motion)
+
+            Returns → :py:obj:`mitsuba.render.SurfaceInteraction`:
+                A detailed surface interaction record. Query its ``is_valid()``
+                method to determine whether an intersection was actually found.
+
+            Parameter ``flags`` (:py:obj:`mitsuba.render.HitComputeFlags`):
+                *no description available*
+
+            Parameter ``active`` (bool):
+                Mask to specify active lanes.
 
     .. py:method:: mitsuba.render.Scene.ray_intersect_naive(self, ray, active=True)
 
@@ -12965,6 +13424,17 @@
             Mask to specify active lanes.
 
         Returns → :py:obj:`mitsuba.render.SurfaceInteraction`:
+            *no description available*
+
+    .. py:method:: mitsuba.render.Scene.ray_intersect_preliminary(self, ray, active=True)
+
+        Parameter ``ray`` (:py:obj:`mitsuba.core.Ray3f`):
+            *no description available*
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → :py:obj:`mitsuba.render.PreliminaryIntersection`:
             *no description available*
 
     .. py:method:: mitsuba.render.Scene.ray_test(self, ray, active=True)
@@ -13005,6 +13475,13 @@
     .. py:method:: mitsuba.render.Scene.shapes(self)
 
         Returns → list:
+            *no description available*
+
+    .. py:method:: mitsuba.render.Scene.shapes_grad_enabled(self)
+
+        Return whether any of the shape's parameters require gradient
+
+        Returns → bool:
             *no description available*
 
 .. py:class:: mitsuba.render.Sensor
@@ -13056,19 +13533,6 @@
         be used for anything except creating clones.
 
         Returns → :py:obj:`mitsuba.render.Sampler`:
-            *no description available*
-
-    .. py:method:: mitsuba.render.Sensor.set_crop_window(self, crop_size, crop_offset)
-
-        Updates the film's crop window, and adjusts any state accordingly.
-
-        Parameter ``crop_size`` (enoki.scalar.Vector2i):
-            *no description available*
-
-        Parameter ``crop_offset`` (enoki.scalar.Vector2i):
-            *no description available*
-
-        Returns → None:
             *no description available*
 
     .. py:method:: mitsuba.render.Sensor.shutter_open(self)
@@ -13143,6 +13607,23 @@
         Returns → :py:obj:`mitsuba.render.BSDF`:
             *no description available*
 
+    .. py:method:: mitsuba.render.Shape.compute_surface_interaction(self, ray, pi, flags=HitComputeFlags.All, active=True)
+
+        Parameter ``ray`` (:py:obj:`mitsuba.core.Ray3f`):
+            *no description available*
+
+        Parameter ``pi`` (:py:obj:`mitsuba.render.PreliminaryIntersection3f`):
+            *no description available*
+
+        Parameter ``flags`` (:py:obj:`mitsuba.render.HitComputeFlags`):
+            *no description available*
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → :py:obj:`mitsuba.render.SurfaceInteraction3f`:
+            *no description available*
+
     .. py:method:: mitsuba.render.Shape.effective_primitive_count(self)
 
         Return the number of primitives (triangles, hairs, ..) contributed to
@@ -13167,23 +13648,6 @@
         Return the medium that lies on the exterior of this shape
 
         Returns → :py:obj:`mitsuba.render.Medium`:
-            *no description available*
-
-    .. py:method:: mitsuba.render.Shape.fill_surface_interaction(self, ray, cache, si, active=True)
-
-        Parameter ``ray`` (:py:obj:`mitsuba.core.Ray3f`):
-            *no description available*
-
-        Parameter ``cache`` (float):
-            *no description available*
-
-        Parameter ``si`` (:py:obj:`mitsuba.render.SurfaceInteraction3f`):
-            *no description available*
-
-        Parameter ``active`` (bool):
-            Mask to specify active lanes.
-
-        Returns → None:
             *no description available*
 
     .. py:method:: mitsuba.render.Shape.id(self)
@@ -13228,27 +13692,13 @@
         Returns → bool:
             *no description available*
 
-    .. py:method:: mitsuba.render.Shape.normal_derivative(self, si, shading_frame=True, active=True)
+    .. py:method:: mitsuba.render.Shape.parameters_grad_enabled(self)
 
-        Return the derivative of the normal vector with respect to the UV
-        parameterization
+        Return whether shape's parameters require gradients (default
+        implementation return false)
 
-        This can be used to compute Gaussian and principal curvatures, amongst
-        other things.
-
-        Parameter ``si`` (:py:obj:`mitsuba.render.SurfaceInteraction3f`):
-            Surface interaction associated with the query
-
-        Parameter ``shading_frame`` (bool):
-            Specifies whether to compute the derivative of the geometric
-            normal *or* the shading normal of the surface
-
-        Parameter ``active`` (bool):
-            Mask to specify active lanes.
-
-        Returns → Tuple[enoki.scalar.Vector3f, enoki.scalar.Vector3f]:
-            The partial derivatives of the normal vector with respect to ``u``
-            and ``v``.
+        Returns → bool:
+            *no description available*
 
     .. py:method:: mitsuba.render.Shape.pdf_direction(self, it, ps, active=True)
 
@@ -13290,7 +13740,26 @@
         Returns → int:
             *no description available*
 
-    .. py:method:: mitsuba.render.Shape.ray_intersect(self, ray, active=True)
+    .. py:method:: mitsuba.render.Shape.ray_intersect(self, ray, flags=HitComputeFlags.All, active=True)
+
+        Test for an intersection and return detailed information
+
+        This operation combines the prior ray_intersect_preliminary() and
+        compute_surface_interaction() operations.
+
+        Parameter ``ray`` (:py:obj:`mitsuba.core.Ray3f`):
+            The ray to be tested for an intersection
+
+        Parameter ``flags`` (:py:obj:`mitsuba.render.HitComputeFlags`):
+            Describe how the detailed information should be computed
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → :py:obj:`mitsuba.render.SurfaceInteraction3f`:
+            *no description available*
+
+    .. py:method:: mitsuba.render.Shape.ray_intersect_preliminary(self, ray, active=True)
 
         Fast ray intersection test
 
@@ -13313,7 +13782,7 @@
         Parameter ``active`` (bool):
             Mask to specify active lanes.
 
-        Returns → :py:obj:`mitsuba.render.SurfaceInteraction3f`:
+        Returns → :py:obj:`mitsuba.render.PreliminaryIntersection3f`:
             *no description available*
 
     .. py:method:: mitsuba.render.Shape.ray_test(self, ray, active=True)
@@ -13574,7 +14043,7 @@
             Returns → :py:obj:`mitsuba.render.BSDF`:
                 *no description available*
 
-    .. py:method:: mitsuba.render.SurfaceInteraction3f.compute_partials(self, ray)
+    .. py:method:: mitsuba.render.SurfaceInteraction3f.compute_uv_partials(self, ray)
 
         Computes texture coordinate partials
 
@@ -13583,6 +14052,16 @@
 
         Returns → None:
             *no description available*
+
+    .. py:method:: mitsuba.render.SurfaceInteraction3f.dn_du
+        :property:
+
+        Normal partials wrt. the UV parameterization
+
+    .. py:method:: mitsuba.render.SurfaceInteraction3f.dn_dv
+        :property:
+
+        Normal partials wrt. the UV parameterization
 
     .. py:method:: mitsuba.render.SurfaceInteraction3f.dp_du
         :property:
@@ -13616,6 +14095,11 @@
             Mask to specify active lanes.
 
         Returns → :py:obj:`mitsuba.render.Emitter`:
+            *no description available*
+
+    .. py:method:: mitsuba.render.SurfaceInteraction3f.has_n_partials(self)
+
+        Returns → bool:
             *no description available*
 
     .. py:method:: mitsuba.render.SurfaceInteraction3f.has_uv_partials(self)
@@ -13888,10 +14372,23 @@
         Returns → float:
             *no description available*
 
-    .. py:method:: mitsuba.render.Texture.pdf(self, si, active=True)
+    .. py:method:: mitsuba.render.Texture.pdf_position(self, p, active=True)
 
-        Evaluate the density function of the sample() method as a probability
-        per unit wavelength (in units of 1/nm).
+        Returns the probability per unit area of sample_position()
+
+        Parameter ``p`` (enoki.scalar.Vector2f):
+            *no description available*
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → float:
+            *no description available*
+
+    .. py:method:: mitsuba.render.Texture.pdf_spectrum(self, si, active=True)
+
+        Evaluate the density function of the sample_spectrum() method as a
+        probability per unit wavelength (in units of 1/nm).
 
         Not every implementation necessarily provides this function. The
         default implementation throws an exception.
@@ -13906,7 +14403,30 @@
             A density value for each wavelength in ``si.wavelengths`` (hence
             the Wavelength type).
 
-    .. py:method:: mitsuba.render.Texture.sample(self, si, sample, active=True)
+    .. py:method:: mitsuba.render.Texture.sample_position(self, sample, active=True)
+
+        Importance sample a surface position proportional to the overall
+        spectral reflectance or intensity of the texture
+
+        This function assumes that the texture is implemented as a mapping
+        from 2D UV positions to texture values, which is not necessarily true
+        for all textures (e.g. 3D noise functions, mesh attributes, etc.). For
+        this reason, not every will plugin provide a specialized
+        implementation, and the default implementation simply return the input
+        sample (i.e. uniform sampling is used).
+
+        Parameter ``sample`` (enoki.scalar.Vector2f):
+            A 2D vector of uniform variates
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → Tuple[enoki.scalar.Vector2f, float]:
+            1. A texture-space position in the range :math:`[0, 1]^2`
+
+        2. The associated probability per unit area in UV space
+
+    .. py:method:: mitsuba.render.Texture.sample_spectrum(self, si, sample, active=True)
 
         Importance sample a set of wavelengths proportional to the spectrum
         defined at the given surface position
@@ -14059,6 +14579,17 @@
 
 .. py:function:: mitsuba.render.has_flag(overloaded)
 
+
+    .. py:function:: has_flag(arg0, arg1)
+
+        Parameter ``arg0`` (:py:obj:`mitsuba.render.HitComputeFlags`):
+            *no description available*
+
+        Parameter ``arg1`` (:py:obj:`mitsuba.render.HitComputeFlags`):
+            *no description available*
+
+        Returns → bool:
+            *no description available*
 
     .. py:function:: has_flag(arg0, arg1)
 
@@ -14965,6 +15496,13 @@
         Converts all Enoki arrays into PyTorch arrays and return them as a
         dictionary. This is mainly useful when using PyTorch to optimize a
         Mitsuba scene.
+
+    .. py:method:: mitsuba.python.util.ParameterMap.set_dirty(key: str)
+
+        Marks a specific parameter and its parent objects as dirty. A subsequent call
+        to :py:meth:`~:py:obj:`mitsuba.python.util.ParameterMap.update`()` will refresh their internal
+        state. This function is automatically called when overwriting a parameter using
+        :py:meth:`~:py:obj:`mitsuba.python.util.ParameterMap.__setitem__`()`.
 
     .. py:method:: mitsuba.python.util.ParameterMap.update() -> None
 

--- a/docs/generated/python_api.rst
+++ b/docs/generated/python_api.rst
@@ -7,50 +7,50 @@ Chi2
 ----
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14799
-  :end-line: 14811
+  :start-line: 15330
+  :end-line: 15342
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14812
-  :end-line: 14911
+  :start-line: 15343
+  :end-line: 15442
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14912
-  :end-line: 14915
+  :start-line: 15443
+  :end-line: 15446
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14916
-  :end-line: 14920
+  :start-line: 15447
+  :end-line: 15451
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14921
-  :end-line: 14933
+  :start-line: 15452
+  :end-line: 15464
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14934
-  :end-line: 14937
+  :start-line: 15465
+  :end-line: 15468
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14938
-  :end-line: 14942
+  :start-line: 15469
+  :end-line: 15473
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14943
-  :end-line: 14946
+  :start-line: 15474
+  :end-line: 15477
 
 ------------
 
@@ -58,44 +58,44 @@ Autodiff
 --------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14994
-  :end-line: 15018
+  :start-line: 15532
+  :end-line: 15556
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15019
-  :end-line: 15040
+  :start-line: 15557
+  :end-line: 15578
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15041
-  :end-line: 15074
+  :start-line: 15579
+  :end-line: 15612
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15075
-  :end-line: 15079
+  :start-line: 15613
+  :end-line: 15617
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15080
-  :end-line: 15129
+  :start-line: 15618
+  :end-line: 15667
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15130
-  :end-line: 15131
+  :start-line: 15668
+  :end-line: 15669
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15132
-  :end-line: 15136
+  :start-line: 15670
+  :end-line: 15674
 
 ------------
 
@@ -103,86 +103,86 @@ Other
 -----
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14947
-  :end-line: 14980
+  :start-line: 15478
+  :end-line: 15518
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14981
-  :end-line: 14982
+  :start-line: 15519
+  :end-line: 15520
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14983
-  :end-line: 14989
+  :start-line: 15521
+  :end-line: 15527
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14990
-  :end-line: 14993
+  :start-line: 15528
+  :end-line: 15531
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15137
-  :end-line: 15140
+  :start-line: 15675
+  :end-line: 15678
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15141
-  :end-line: 15361
+  :start-line: 15679
+  :end-line: 15899
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15362
-  :end-line: 15374
+  :start-line: 15900
+  :end-line: 15912
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15375
-  :end-line: 15376
+  :start-line: 15913
+  :end-line: 15914
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15377
-  :end-line: 15385
+  :start-line: 15915
+  :end-line: 15923
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15386
-  :end-line: 15395
+  :start-line: 15924
+  :end-line: 15933
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15396
-  :end-line: 15397
+  :start-line: 15934
+  :end-line: 15935
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15398
-  :end-line: 15401
+  :start-line: 15936
+  :end-line: 15939
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15402
-  :end-line: 15405
+  :start-line: 15940
+  :end-line: 15943
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 15406
-  :end-line: 15416
+  :start-line: 15944
+  :end-line: 15954
 
 ------------
 

--- a/docs/generated/render_api.rst
+++ b/docs/generated/render_api.rst
@@ -7,44 +7,44 @@ BSDF
 ----
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10706
-  :end-line: 10928
+  :start-line: 10950
+  :end-line: 11172
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10929
-  :end-line: 10995
+  :start-line: 11173
+  :end-line: 11239
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 10996
-  :end-line: 11097
+  :start-line: 11240
+  :end-line: 11341
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 11098
-  :end-line: 11150
+  :start-line: 11342
+  :end-line: 11394
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 13932
-  :end-line: 13952
+  :start-line: 14452
+  :end-line: 14472
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 12255
-  :end-line: 12478
+  :start-line: 12561
+  :end-line: 12784
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 12479
-  :end-line: 12499
+  :start-line: 12785
+  :end-line: 12805
 
 ------------
 
@@ -52,8 +52,8 @@ Endpoint
 --------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 11332
-  :end-line: 11541
+  :start-line: 11576
+  :end-line: 11785
 
 ------------
 
@@ -61,14 +61,14 @@ Emitter
 -------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 11270
-  :end-line: 11290
+  :start-line: 11514
+  :end-line: 11534
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 11291
-  :end-line: 11331
+  :start-line: 11535
+  :end-line: 11575
 
 ------------
 
@@ -76,14 +76,14 @@ Sensor
 ------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 13009
-  :end-line: 13086
+  :start-line: 13486
+  :end-line: 13550
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 12713
-  :end-line: 12750
+  :start-line: 13089
+  :end-line: 13126
 
 ------------
 
@@ -91,26 +91,26 @@ Medium
 ------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 11974
-  :end-line: 12059
+  :start-line: 12269
+  :end-line: 12354
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 12504
-  :end-line: 12567
+  :start-line: 12810
+  :end-line: 12873
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 12568
-  :end-line: 12586
+  :start-line: 12874
+  :end-line: 12892
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 12587
-  :end-line: 12619
+  :start-line: 12893
+  :end-line: 12925
 
 ------------
 
@@ -118,14 +118,14 @@ Shape
 -----
 
 .. include:: extracted_rst_api.rst
-  :start-line: 13087
-  :end-line: 13397
+  :start-line: 13551
+  :end-line: 13866
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 12112
-  :end-line: 12254
+  :start-line: 12407
+  :end-line: 12560
 
 ------------
 
@@ -136,8 +136,8 @@ Film
 ----
 
 .. include:: extracted_rst_api.rst
-  :start-line: 11542
-  :end-line: 11676
+  :start-line: 11786
+  :end-line: 11920
 
 ------------
 
@@ -145,8 +145,8 @@ Sampler
 -------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 12751
-  :end-line: 12817
+  :start-line: 13127
+  :end-line: 13253
 
 ------------
 
@@ -154,14 +154,14 @@ Scene
 -----
 
 .. include:: extracted_rst_api.rst
-  :start-line: 12898
-  :end-line: 13008
+  :start-line: 13334
+  :end-line: 13485
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 13398
-  :end-line: 13454
+  :start-line: 13867
+  :end-line: 13923
 
 ------------
 
@@ -169,26 +169,26 @@ Record
 ------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 12620
-  :end-line: 12712
+  :start-line: 12926
+  :end-line: 13018
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 11151
-  :end-line: 11269
+  :start-line: 11395
+  :end-line: 11513
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 12060
-  :end-line: 12111
+  :start-line: 12355
+  :end-line: 12406
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 13525
-  :end-line: 13792
+  :start-line: 13994
+  :end-line: 14276
 
 ------------
 
@@ -196,98 +196,98 @@ Polarization
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14084
-  :end-line: 14106
+  :start-line: 14615
+  :end-line: 14637
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14107
-  :end-line: 14129
+  :start-line: 14638
+  :end-line: 14660
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14130
-  :end-line: 14162
+  :start-line: 14661
+  :end-line: 14693
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14163
-  :end-line: 14193
+  :start-line: 14694
+  :end-line: 14724
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14194
-  :end-line: 14230
+  :start-line: 14725
+  :end-line: 14761
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14231
-  :end-line: 14255
+  :start-line: 14762
+  :end-line: 14786
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14256
-  :end-line: 14338
+  :start-line: 14787
+  :end-line: 14869
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14339
-  :end-line: 14399
+  :start-line: 14870
+  :end-line: 14930
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14400
-  :end-line: 14429
+  :start-line: 14931
+  :end-line: 14960
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14430
-  :end-line: 14459
+  :start-line: 14961
+  :end-line: 14990
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14460
-  :end-line: 14490
+  :start-line: 14991
+  :end-line: 15021
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14491
-  :end-line: 14531
+  :start-line: 15022
+  :end-line: 15062
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14532
-  :end-line: 14568
+  :start-line: 15063
+  :end-line: 15099
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14569
-  :end-line: 14605
+  :start-line: 15100
+  :end-line: 15136
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14606
-  :end-line: 14622
+  :start-line: 15137
+  :end-line: 15153
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14623
-  :end-line: 14633
+  :start-line: 15154
+  :end-line: 15164
 
 ------------
 
@@ -295,140 +295,152 @@ Other
 -----
 
 .. include:: extracted_rst_api.rst
-  :start-line: 11677
-  :end-line: 11867
+  :start-line: 11921
+  :end-line: 11971
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 11868
-  :end-line: 11911
+  :start-line: 11972
+  :end-line: 12162
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 11912
-  :end-line: 11973
+  :start-line: 12163
+  :end-line: 12206
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 12500
-  :end-line: 12503
+  :start-line: 12207
+  :end-line: 12268
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 12818
-  :end-line: 12897
+  :start-line: 12806
+  :end-line: 12809
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 13455
-  :end-line: 13524
+  :start-line: 13019
+  :end-line: 13088
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 13793
-  :end-line: 13931
+  :start-line: 13254
+  :end-line: 13333
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 13953
-  :end-line: 13972
+  :start-line: 13924
+  :end-line: 13993
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 13973
-  :end-line: 14000
+  :start-line: 14277
+  :end-line: 14451
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14001
-  :end-line: 14021
+  :start-line: 14473
+  :end-line: 14492
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14022
-  :end-line: 14058
+  :start-line: 14493
+  :end-line: 14520
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14059
-  :end-line: 14083
+  :start-line: 14521
+  :end-line: 14541
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14634
-  :end-line: 14659
+  :start-line: 14542
+  :end-line: 14578
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14660
-  :end-line: 14701
+  :start-line: 14579
+  :end-line: 14614
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14702
-  :end-line: 14712
+  :start-line: 15165
+  :end-line: 15190
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14713
-  :end-line: 14723
+  :start-line: 15191
+  :end-line: 15232
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14724
-  :end-line: 14734
+  :start-line: 15233
+  :end-line: 15243
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14735
-  :end-line: 14745
+  :start-line: 15244
+  :end-line: 15254
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14746
-  :end-line: 14756
+  :start-line: 15255
+  :end-line: 15265
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14757
-  :end-line: 14767
+  :start-line: 15266
+  :end-line: 15276
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14768
-  :end-line: 14778
+  :start-line: 15277
+  :end-line: 15287
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14779
-  :end-line: 14790
+  :start-line: 15288
+  :end-line: 15298
 
 ------------
 
 .. include:: extracted_rst_api.rst
-  :start-line: 14791
-  :end-line: 14798
+  :start-line: 15299
+  :end-line: 15309
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 15310
+  :end-line: 15321
+
+------------
+
+.. include:: extracted_rst_api.rst
+  :start-line: 15322
+  :end-line: 15329
 
 ------------
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -23,6 +23,44 @@
   year = {2016},
 }
 
+@article{kensler1967correlated,
+  title={Correlated multi-jittered sampling},
+  author={Kensler, Andrew},
+  journal={Mathematical Physics and applied mathematics},
+  volume={7},
+  pages={86--112},
+  year={1967}
+}
+
+@article {Kollig2002Efficient,
+    author = {Kollig, Thomas and Keller, Alexander},
+    title = {{Efficient Multidimensional Sampling}},
+    journal = {Computer Graphics Forum},
+    year = {2002},
+    editor = {},
+    volume = {21},
+    number = {3},
+    publisher = {Blackwell Publishers, Inc and the Eurographics Association},
+    pages = {557-563},
+    DOI = {10.1111/1467-8659.00706}
+}
+
+@article{jarosz19orthogonal,
+    author = "Jarosz, Wojciech and Enayet, Afnan and Kensler, Andrew and Kilpatrick, Charlie and Christensen, Per",
+    title = "Orthogonal array sampling for {{Monte}} {{Carlo}} rendering",
+    journal = "Computer Graphics Forum (Proceedings of EGSR)",
+    year = "2019",
+    volume = "38",
+    number = "4",
+    month = jul,
+    pages = "135--147",
+    doi = "10/gf6rx5",
+    publisher = "The Eurographics Association",
+    abstract = "We generalize N-rooks, jittered, and (correlated) multi-jittered sampling to higher dimensions by importing and improving upon a class of techniques called orthogonal arrays from the statistics literature. Renderers typically combine or ``pad'' a collection of lower-dimensional (e.g. 2D and 1D) stratified patterns to form higher-dimensional samples for integration. This maintains stratification in the original dimension pairs, but looses it for all other dimension pairs. For truly multi-dimensional integrands like those in rendering, this increases variance and deteriorates its rate of convergence to that of pure random sampling. Care must therefore be taken to assign the primary dimension pairs to the dimensions with most integrand variation, but this complicates implementations. We tackle this problem by developing a collection of practical, in-place multi-dimensional sample generation routines that stratify points on all t-dimensional and 1-dimensional projections simultaneously. For instance, when t=2, any 2D projection of our samples is a (correlated) multi-jittered point set. This property not only reduces variance, but also simplifies implementations since sample dimensions can now be assigned to integrand dimensions arbitrarily while maintaining the same level of stratification. Our techniques reduce variance compared to traditional 2D padding approaches like PBRT's (0,2) and Stratified samplers, and provide quality nearly equal to state-of-the-art QMC samplers like Sobol and Halton while avoiding their structured artifacts as commonly seen when using a single sample set to cover an entire image. While in this work we focus on constructing finite sampling point sets, we also discuss potential avenues for extending our work to progressive sequences (more suitable for incremental rendering) in the future."
+}
+
+
+
 @article{Jakob2019Spectral,
 	author = {Wenzel Jakob and Johannes Hanika},
 	title = {A Low-Dimensional Function Space for Efficient Spectral Upsampling},

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -23,163 +23,11 @@
 #endif
 
 
-static const char *__doc_CUctx_st = R"doc()doc";
-
-static const char *__doc_CUstream_st = R"doc()doc";
-
-static const char *__doc_OptixAabb = R"doc()doc";
-
-static const char *__doc_OptixAabb_maxX = R"doc()doc";
-
-static const char *__doc_OptixAabb_maxY = R"doc()doc";
-
-static const char *__doc_OptixAabb_maxZ = R"doc()doc";
-
-static const char *__doc_OptixAabb_minX = R"doc()doc";
-
-static const char *__doc_OptixAabb_minY = R"doc()doc";
-
-static const char *__doc_OptixAabb_minZ = R"doc()doc";
-
-static const char *__doc_OptixAccelBufferSizes = R"doc()doc";
-
-static const char *__doc_OptixAccelBufferSizes_outputSizeInBytes = R"doc()doc";
-
-static const char *__doc_OptixAccelBufferSizes_tempSizeInBytes = R"doc()doc";
-
-static const char *__doc_OptixAccelBufferSizes_tempUpdateSizeInBytes = R"doc()doc";
-
-static const char *__doc_OptixAccelBuildOptions = R"doc()doc";
-
-static const char *__doc_OptixAccelBuildOptions_buildFlags = R"doc()doc";
-
-static const char *__doc_OptixAccelBuildOptions_motionOptions = R"doc()doc";
-
-static const char *__doc_OptixAccelBuildOptions_operation = R"doc()doc";
-
-static const char *__doc_OptixAccelEmitDesc = R"doc()doc";
-
-static const char *__doc_OptixAccelEmitDesc_result = R"doc()doc";
-
-static const char *__doc_OptixAccelEmitDesc_type = R"doc()doc";
-
-static const char *__doc_OptixBuildInput = R"doc()doc";
-
-static const char *__doc_OptixBuildInputCustomPrimitiveArray = R"doc()doc";
-
-static const char *__doc_OptixBuildInputCustomPrimitiveArray_aabbBuffers = R"doc()doc";
-
-static const char *__doc_OptixBuildInputCustomPrimitiveArray_flags = R"doc()doc";
-
-static const char *__doc_OptixBuildInputCustomPrimitiveArray_numPrimitives = R"doc()doc";
-
-static const char *__doc_OptixBuildInputCustomPrimitiveArray_numSbtRecords = R"doc()doc";
-
-static const char *__doc_OptixBuildInputCustomPrimitiveArray_primitiveIndexOffset = R"doc()doc";
-
-static const char *__doc_OptixBuildInputCustomPrimitiveArray_sbtIndexOffsetBuffer = R"doc()doc";
-
-static const char *__doc_OptixBuildInputCustomPrimitiveArray_sbtIndexOffsetSizeInBytes = R"doc()doc";
-
-static const char *__doc_OptixBuildInputCustomPrimitiveArray_sbtIndexOffsetStrideInBytes = R"doc()doc";
-
-static const char *__doc_OptixBuildInputCustomPrimitiveArray_strideInBytes = R"doc()doc";
-
-static const char *__doc_OptixBuildInputInstanceArray = R"doc()doc";
-
-static const char *__doc_OptixBuildInputInstanceArray_aabbs = R"doc()doc";
-
-static const char *__doc_OptixBuildInputInstanceArray_instances = R"doc()doc";
-
-static const char *__doc_OptixBuildInputInstanceArray_numAabbs = R"doc()doc";
-
-static const char *__doc_OptixBuildInputInstanceArray_numInstances = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_flags = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_indexBuffer = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_indexFormat = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_indexStrideInBytes = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_numIndexTriplets = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_numSbtRecords = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_numVertices = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_preTransform = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_primitiveIndexOffset = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_sbtIndexOffsetBuffer = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_sbtIndexOffsetSizeInBytes = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_sbtIndexOffsetStrideInBytes = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_vertexBuffers = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_vertexFormat = R"doc()doc";
-
-static const char *__doc_OptixBuildInputTriangleArray_vertexStrideInBytes = R"doc()doc";
-
-static const char *__doc_OptixBuildInput_type = R"doc()doc";
-
-static const char *__doc_OptixDeviceContextOptions = R"doc()doc";
-
-static const char *__doc_OptixDeviceContextOptions_logCallbackData = R"doc()doc";
-
-static const char *__doc_OptixDeviceContextOptions_logCallbackFunction = R"doc()doc";
-
-static const char *__doc_OptixDeviceContextOptions_logCallbackLevel = R"doc()doc";
-
-static const char *__doc_OptixDeviceContext_t = R"doc()doc";
-
 static const char *__doc_OptixHitGroupData = R"doc(Stores information about a Shape on the Optix side)doc";
 
 static const char *__doc_OptixHitGroupData_data = R"doc(Pointer to the memory region of Shape data (e.g. ``OptixMeshData`` ))doc";
 
 static const char *__doc_OptixHitGroupData_shape_ptr = R"doc(Pointer to the associated shape)doc";
-
-static const char *__doc_OptixInstance = R"doc()doc";
-
-static const char *__doc_OptixInstance_flags = R"doc()doc";
-
-static const char *__doc_OptixInstance_instanceId = R"doc()doc";
-
-static const char *__doc_OptixInstance_pad = R"doc()doc";
-
-static const char *__doc_OptixInstance_sbtOffset = R"doc()doc";
-
-static const char *__doc_OptixInstance_transform = R"doc()doc";
-
-static const char *__doc_OptixInstance_traversableHandle = R"doc()doc";
-
-static const char *__doc_OptixInstance_visibilityMask = R"doc()doc";
-
-static const char *__doc_OptixModuleCompileOptions = R"doc()doc";
-
-static const char *__doc_OptixModuleCompileOptions_debugLevel = R"doc()doc";
-
-static const char *__doc_OptixModuleCompileOptions_maxRegisterCount = R"doc()doc";
-
-static const char *__doc_OptixModuleCompileOptions_optLevel = R"doc()doc";
-
-static const char *__doc_OptixModule_t = R"doc()doc";
-
-static const char *__doc_OptixMotionOptions = R"doc()doc";
-
-static const char *__doc_OptixMotionOptions_flags = R"doc()doc";
-
-static const char *__doc_OptixMotionOptions_numKeys = R"doc()doc";
-
-static const char *__doc_OptixMotionOptions_timeBegin = R"doc()doc";
-
-static const char *__doc_OptixMotionOptions_timeEnd = R"doc()doc";
 
 static const char *__doc_OptixParams =
 R"doc(Launch-varying data structure specifying data pointers for the input
@@ -226,96 +74,6 @@ static const char *__doc_OptixParams_out_shape_ptr = R"doc()doc";
 static const char *__doc_OptixParams_out_t = R"doc(Output surface interaction data pointers)doc";
 
 static const char *__doc_OptixParams_out_uv = R"doc(Output surface interaction data pointers)doc";
-
-static const char *__doc_OptixPipelineCompileOptions = R"doc()doc";
-
-static const char *__doc_OptixPipelineCompileOptions_exceptionFlags = R"doc()doc";
-
-static const char *__doc_OptixPipelineCompileOptions_numAttributeValues = R"doc()doc";
-
-static const char *__doc_OptixPipelineCompileOptions_numPayloadValues = R"doc()doc";
-
-static const char *__doc_OptixPipelineCompileOptions_pipelineLaunchParamsVariableName = R"doc()doc";
-
-static const char *__doc_OptixPipelineCompileOptions_traversableGraphFlags = R"doc()doc";
-
-static const char *__doc_OptixPipelineCompileOptions_usesMotionBlur = R"doc()doc";
-
-static const char *__doc_OptixPipelineLinkOptions = R"doc()doc";
-
-static const char *__doc_OptixPipelineLinkOptions_debugLevel = R"doc()doc";
-
-static const char *__doc_OptixPipelineLinkOptions_maxTraceDepth = R"doc()doc";
-
-static const char *__doc_OptixPipelineLinkOptions_overrideUsesMotionBlur = R"doc()doc";
-
-static const char *__doc_OptixPipeline_t = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupCallables = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupCallables_entryFunctionNameCC = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupCallables_entryFunctionNameDC = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupCallables_moduleCC = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupCallables_moduleDC = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupDesc = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupDesc_flags = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupDesc_kind = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupHitgroup = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupHitgroup_entryFunctionNameAH = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupHitgroup_entryFunctionNameCH = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupHitgroup_entryFunctionNameIS = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupHitgroup_moduleAH = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupHitgroup_moduleCH = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupHitgroup_moduleIS = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupOptions = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupOptions_placeholder = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupSingleModule = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupSingleModule_entryFunctionName = R"doc()doc";
-
-static const char *__doc_OptixProgramGroupSingleModule_module = R"doc()doc";
-
-static const char *__doc_OptixProgramGroup_t = R"doc()doc";
-
-static const char *__doc_OptixShaderBindingTable = R"doc()doc";
-
-static const char *__doc_OptixShaderBindingTable_callablesRecordBase = R"doc()doc";
-
-static const char *__doc_OptixShaderBindingTable_callablesRecordCount = R"doc()doc";
-
-static const char *__doc_OptixShaderBindingTable_callablesRecordStrideInBytes = R"doc()doc";
-
-static const char *__doc_OptixShaderBindingTable_exceptionRecord = R"doc()doc";
-
-static const char *__doc_OptixShaderBindingTable_hitgroupRecordBase = R"doc()doc";
-
-static const char *__doc_OptixShaderBindingTable_hitgroupRecordCount = R"doc()doc";
-
-static const char *__doc_OptixShaderBindingTable_hitgroupRecordStrideInBytes = R"doc()doc";
-
-static const char *__doc_OptixShaderBindingTable_missRecordBase = R"doc()doc";
-
-static const char *__doc_OptixShaderBindingTable_missRecordCount = R"doc()doc";
-
-static const char *__doc_OptixShaderBindingTable_missRecordStrideInBytes = R"doc()doc";
-
-static const char *__doc_OptixShaderBindingTable_raygenRecord = R"doc()doc";
 
 static const char *__doc_enoki_operator_lshift = R"doc(Prints the canonical representation of a PCG32 object.)doc";
 
@@ -566,6 +324,8 @@ See also:
 static const char *__doc_mitsuba_BSDF_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_BSDF_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_BSDF_4 = R"doc()doc";
 
 static const char *__doc_mitsuba_BSDFContext =
 R"doc(Context data structure for BSDF evaluation and sampling
@@ -2154,6 +1914,8 @@ static const char *__doc_mitsuba_Emitter_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Emitter_3 = R"doc()doc";
 
+static const char *__doc_mitsuba_Emitter_4 = R"doc()doc";
+
 static const char *__doc_mitsuba_EmitterFlags =
 R"doc(This list of flags is used to classify the different types of
 emitters.)doc";
@@ -2213,6 +1975,8 @@ may be set to ``nullptr`` when it is surrounded by vacuum).)doc";
 static const char *__doc_mitsuba_Endpoint_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Endpoint_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_Endpoint_4 = R"doc()doc";
 
 static const char *__doc_mitsuba_Endpoint_Endpoint = R"doc(//! @})doc";
 
@@ -2512,6 +2276,8 @@ then committed to the film using the put() method.)doc";
 static const char *__doc_mitsuba_Film_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Film_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_Film_4 = R"doc()doc";
 
 static const char *__doc_mitsuba_Film_Film = R"doc(Create a film)doc";
 
@@ -2872,6 +2638,8 @@ static const char *__doc_mitsuba_ImageBlock_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_ImageBlock_3 = R"doc()doc";
 
+static const char *__doc_mitsuba_ImageBlock_4 = R"doc()doc";
+
 static const char *__doc_mitsuba_ImageBlock_ImageBlock =
 R"doc(Construct a new image block of the requested properties
 
@@ -3035,6 +2803,8 @@ different kinds of implementations.)doc";
 static const char *__doc_mitsuba_Integrator_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Integrator_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_Integrator_4 = R"doc()doc";
 
 static const char *__doc_mitsuba_Integrator_Integrator = R"doc(Create an integrator)doc";
 
@@ -3417,6 +3187,8 @@ static const char *__doc_mitsuba_Medium_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_3 = R"doc()doc";
 
+static const char *__doc_mitsuba_Medium_4 = R"doc()doc";
+
 static const char *__doc_mitsuba_MediumInteraction = R"doc(Stores information related to a medium scattering interaction)doc";
 
 static const char *__doc_mitsuba_MediumInteraction_MediumInteraction = R"doc()doc";
@@ -3686,6 +3458,8 @@ static const char *__doc_mitsuba_Mesh_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_3 = R"doc()doc";
 
+static const char *__doc_mitsuba_Mesh_4 = R"doc()doc";
+
 static const char *__doc_mitsuba_Mesh_Mesh = R"doc(Create a new mesh with the given vertex and face data structures)doc";
 
 static const char *__doc_mitsuba_Mesh_Mesh_2 = R"doc()doc";
@@ -3783,8 +3557,6 @@ static const char *__doc_mitsuba_Mesh_m_name = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_m_parameterization = R"doc(Optional: used in eval_parameterization())doc";
 
-static const char *__doc_mitsuba_Mesh_m_vertex_buffer_ptr = R"doc()doc";
-
 static const char *__doc_mitsuba_Mesh_m_vertex_count = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_m_vertex_normals_buf = R"doc()doc";
@@ -3792,10 +3564,6 @@ static const char *__doc_mitsuba_Mesh_m_vertex_normals_buf = R"doc()doc";
 static const char *__doc_mitsuba_Mesh_m_vertex_positions_buf = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_m_vertex_texcoords_buf = R"doc()doc";
-
-static const char *__doc_mitsuba_Mesh_optix_build_input = R"doc()doc";
-
-static const char *__doc_mitsuba_Mesh_optix_prepare_geometry = R"doc()doc";
 
 static const char *__doc_mitsuba_Mesh_parameters_changed = R"doc()doc";
 
@@ -4027,6 +3795,8 @@ static const char *__doc_mitsuba_MonteCarloIntegrator_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_MonteCarloIntegrator_3 = R"doc()doc";
 
+static const char *__doc_mitsuba_MonteCarloIntegrator_4 = R"doc()doc";
+
 static const char *__doc_mitsuba_MonteCarloIntegrator_MonteCarloIntegrator = R"doc(Create an integrator)doc";
 
 static const char *__doc_mitsuba_MonteCarloIntegrator_class = R"doc()doc";
@@ -4157,11 +3927,31 @@ Remark:
 See also:
     TraversalCallback)doc";
 
+static const char *__doc_mitsuba_PCG32Sampler =
+R"doc(Interface for sampler plugins based on the PCG32 random number
+generator)doc";
+
+static const char *__doc_mitsuba_PCG32Sampler_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_PCG32Sampler_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_PCG32Sampler_4 = R"doc()doc";
+
+static const char *__doc_mitsuba_PCG32Sampler_PCG32Sampler = R"doc()doc";
+
+static const char *__doc_mitsuba_PCG32Sampler_class = R"doc()doc";
+
+static const char *__doc_mitsuba_PCG32Sampler_m_rng = R"doc()doc";
+
+static const char *__doc_mitsuba_PCG32Sampler_seed = R"doc()doc";
+
 static const char *__doc_mitsuba_PhaseFunction = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunction_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunction_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_PhaseFunction_4 = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunctionContext = R"doc()doc";
 
@@ -4496,8 +4286,6 @@ static const char *__doc_mitsuba_ProfilerPhase_SampleEmitterDirection = R"doc()d
 
 static const char *__doc_mitsuba_ProfilerPhase_SampleEmitterRay = R"doc()doc";
 
-static const char *__doc_mitsuba_ProfilerPhase_SamplerSeed = R"doc()doc";
-
 static const char *__doc_mitsuba_ProfilerPhase_SamplingIntegratorSample = R"doc()doc";
 
 static const char *__doc_mitsuba_ProfilerPhase_TextureEvaluate = R"doc()doc";
@@ -4572,6 +4360,8 @@ rendered using the traditional OpenGL pipeline.)doc";
 static const char *__doc_mitsuba_ProjectiveCamera_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_ProjectiveCamera_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_ProjectiveCamera_4 = R"doc()doc";
 
 static const char *__doc_mitsuba_ProjectiveCamera_ProjectiveCamera = R"doc()doc";
 
@@ -4923,24 +4713,6 @@ static const char *__doc_mitsuba_RadicalInverse_scramble = R"doc(Return the orig
 
 static const char *__doc_mitsuba_RadicalInverse_to_string = R"doc(Return a human-readable string representation)doc";
 
-static const char *__doc_mitsuba_RandomSampler = R"doc()doc";
-
-static const char *__doc_mitsuba_RandomSampler_2 = R"doc()doc";
-
-static const char *__doc_mitsuba_RandomSampler_3 = R"doc()doc";
-
-static const char *__doc_mitsuba_RandomSampler_RandomSampler = R"doc()doc";
-
-static const char *__doc_mitsuba_RandomSampler_check_rng = R"doc()doc";
-
-static const char *__doc_mitsuba_RandomSampler_class = R"doc()doc";
-
-static const char *__doc_mitsuba_RandomSampler_m_rng = R"doc()doc";
-
-static const char *__doc_mitsuba_RandomSampler_seed = R"doc()doc";
-
-static const char *__doc_mitsuba_RandomSampler_wavefront_size = R"doc()doc";
-
 static const char *__doc_mitsuba_Ray =
 R"doc(Simple n-dimensional ray segment data structure
 
@@ -5043,6 +4815,8 @@ MTS_FILTER_RESOLUTION.)doc";
 static const char *__doc_mitsuba_ReconstructionFilter_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_ReconstructionFilter_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_ReconstructionFilter_4 = R"doc()doc";
 
 static const char *__doc_mitsuba_ReconstructionFilter_ReconstructionFilter = R"doc(Create a new reconstruction filter)doc";
 
@@ -5159,13 +4933,57 @@ static const char *__doc_mitsuba_Resampler_target_resolution = R"doc(Return the 
 
 static const char *__doc_mitsuba_Resampler_to_string = R"doc(Return a human-readable summary)doc";
 
-static const char *__doc_mitsuba_Sampler = R"doc()doc";
+static const char *__doc_mitsuba_Sampler =
+R"doc(Base class of all sample generators.
+
+For each sample in a pixel, a sample generator produces a
+(hypothetical) point in the infinite dimensional random number cube. A
+rendering algorithm can then request subsequent 1D or 2D components of
+this point using the ``next_1d`` and ``next_2d`` functions.
+
+Scalar and wavefront rendering algorithms will need interact with the
+sampler interface in a slightly different way:
+
+Scalar rendering algorithm:
+
+1. Before beginning to render a pixel block, the rendering algorithm
+calls ``seed`` to initialize a new sequence with the specific seed
+offset. 2. The first pixel sample can now be computed, after which
+``advance`` needs to be invoked. This repeats until all pixel samples
+have been generated. Note that some implementations need to be
+configured for a certain number of pixel samples, and exceeding these
+will lead to an exception being thrown. 3. While computing a pixel
+sample, the rendering algorithm usually requests batches of (pseudo-)
+random numbers using the ``next_1d`` and ``next_2d`` functions before
+moving on to the next sample.
+
+Wavefront rendering algorithm:
+
+1. Before beginning to render the wavefront, the rendering algorithm
+needs to inform the sampler of the amount of samples rendered in
+parallel for every pixel in the wavefront. This can be achieved by
+calling ``set_samples_per_wavefront`` . 2. Then the rendering
+algorithm should seed the sampler and set the appropriate wavefront
+size by calling ``seed``. A different seed value, based on the
+``base_seed`` and the seed offset, will be used for every sample (of
+every pixel) in the wavefront. 3. ``advance`` can be used to advance
+to the next sample in the sequence. 4. As in the scalar approach, the
+rendering algorithm can request batches of (pseudo-) random numbers
+using the ``next_1d`` and ``next_2d`` functions.)doc";
 
 static const char *__doc_mitsuba_Sampler_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Sampler_3 = R"doc()doc";
 
+static const char *__doc_mitsuba_Sampler_4 = R"doc()doc";
+
 static const char *__doc_mitsuba_Sampler_Sampler = R"doc()doc";
+
+static const char *__doc_mitsuba_Sampler_advance =
+R"doc(Advance to the next sample.
+
+A subsequent call to ``next_1d`` or ``next_2d`` will access the first
+1D or 2D components of this sample.)doc";
 
 static const char *__doc_mitsuba_Sampler_class = R"doc()doc";
 
@@ -5180,19 +4998,27 @@ May throw an exception if not supported. Cloning may also change the
 state of the original sampler (e.g. by using the next 1D sample as a
 seed for the clone).)doc";
 
-static const char *__doc_mitsuba_Sampler_m_base_seed = R"doc()doc";
+static const char *__doc_mitsuba_Sampler_compute_per_sequence_seed =
+R"doc(Generates a array of seeds where the seed values are unique per
+sequence)doc";
 
-static const char *__doc_mitsuba_Sampler_m_sample_count = R"doc()doc";
+static const char *__doc_mitsuba_Sampler_current_sample_index = R"doc(Return the index of the current sample)doc";
 
-static const char *__doc_mitsuba_Sampler_m_samples_per_wavefront = R"doc()doc";
+static const char *__doc_mitsuba_Sampler_m_base_seed = R"doc(Base seed value)doc";
 
-static const char *__doc_mitsuba_Sampler_m_wavefront_count = R"doc()doc";
+static const char *__doc_mitsuba_Sampler_m_dimension_index = R"doc(Index of the current dimension in the sample)doc";
+
+static const char *__doc_mitsuba_Sampler_m_sample_count = R"doc(Number of samples per pixel)doc";
+
+static const char *__doc_mitsuba_Sampler_m_sample_index = R"doc(Index of the current sample in the sequence)doc";
+
+static const char *__doc_mitsuba_Sampler_m_samples_per_wavefront = R"doc(Number of samples per pass in wavefront modes (default is 1))doc";
+
+static const char *__doc_mitsuba_Sampler_m_wavefront_size = R"doc(Size of the wavefront (or 0, if not seeded))doc";
 
 static const char *__doc_mitsuba_Sampler_next_1d = R"doc(Retrieve the next component value from the current sample)doc";
 
 static const char *__doc_mitsuba_Sampler_next_2d = R"doc(Retrieve the next two component values from the current sample)doc";
-
-static const char *__doc_mitsuba_Sampler_prepare_wavefront = R"doc(Start the next wavefront)doc";
 
 static const char *__doc_mitsuba_Sampler_sample_count = R"doc(Return the number of samples per pixel)doc";
 
@@ -5200,12 +5026,12 @@ static const char *__doc_mitsuba_Sampler_seed =
 R"doc(Deterministically seed the underlying RNG, if applicable.
 
 In the context of wavefront ray tracing & dynamic arrays, this
-function must be called with a ``seed_value`` matching the size of the
-wavefront.)doc";
+function must be called with ``wavefront_size`` matching the size of
+the wavefront.)doc";
 
-static const char *__doc_mitsuba_Sampler_set_samples_per_wavefront =
-R"doc(Set the number of samples per pass in the wavefront modes (default is
-1))doc";
+static const char *__doc_mitsuba_Sampler_seeded = R"doc(Return whether the sampler was seeded)doc";
+
+static const char *__doc_mitsuba_Sampler_set_samples_per_wavefront = R"doc(Set the number of samples per pass in wavefront modes (default is 1))doc";
 
 static const char *__doc_mitsuba_Sampler_wavefront_size = R"doc(Return the size of the wavefront (or 0, if not seeded))doc";
 
@@ -5220,6 +5046,8 @@ this estimator to compute all pixels of the image.)doc";
 static const char *__doc_mitsuba_SamplingIntegrator_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_SamplingIntegrator_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_SamplingIntegrator_4 = R"doc()doc";
 
 static const char *__doc_mitsuba_SamplingIntegrator_SamplingIntegrator = R"doc(//! @})doc";
 
@@ -5311,6 +5139,8 @@ static const char *__doc_mitsuba_Scene = R"doc()doc";
 static const char *__doc_mitsuba_Scene_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Scene_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_Scene_4 = R"doc()doc";
 
 static const char *__doc_mitsuba_Scene_Scene = R"doc(Instantiate a scene from a Properties object)doc";
 
@@ -5498,6 +5328,8 @@ static const char *__doc_mitsuba_Sensor_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Sensor_3 = R"doc()doc";
 
+static const char *__doc_mitsuba_Sensor_4 = R"doc()doc";
+
 static const char *__doc_mitsuba_Sensor_Sensor = R"doc()doc";
 
 static const char *__doc_mitsuba_Sensor_class = R"doc()doc";
@@ -5592,11 +5424,15 @@ static const char *__doc_mitsuba_Shape_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_3 = R"doc()doc";
 
+static const char *__doc_mitsuba_Shape_4 = R"doc()doc";
+
 static const char *__doc_mitsuba_ShapeKDTree = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeKDTree_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeKDTree_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_ShapeKDTree_4 = R"doc()doc";
 
 static const char *__doc_mitsuba_ShapeKDTree_ShapeKDTree =
 R"doc(Create an empty kd-tree and take build-related parameters from
@@ -5807,8 +5643,6 @@ static const char *__doc_mitsuba_Shape_m_interior_medium = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_m_mesh = R"doc()doc";
 
-static const char *__doc_mitsuba_Shape_m_optix_data_ptr = R"doc(OptiX hitgroup data buffer)doc";
-
 static const char *__doc_mitsuba_Shape_m_sensor = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_m_to_object = R"doc()doc";
@@ -5830,14 +5664,6 @@ static const char *__doc_mitsuba_Shape_operator_new_2 = R"doc()doc";
 static const char *__doc_mitsuba_Shape_operator_new_3 = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_operator_new_4 = R"doc()doc";
-
-static const char *__doc_mitsuba_Shape_optix_build_input = R"doc(Fill the OptixBuildInput struct)doc";
-
-static const char *__doc_mitsuba_Shape_optix_hitgroup_data =
-R"doc(Return a pointer (GPU memory) to the shape's OptiX hitgroup data
-buffer)doc";
-
-static const char *__doc_mitsuba_Shape_optix_prepare_geometry = R"doc(Prepare OptiX data buffers)doc";
 
 static const char *__doc_mitsuba_Shape_parameters_changed = R"doc()doc";
 
@@ -7192,6 +7018,8 @@ static const char *__doc_mitsuba_Texture_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Texture_3 = R"doc()doc";
 
+static const char *__doc_mitsuba_Texture_4 = R"doc()doc";
+
 static const char *__doc_mitsuba_Texture_D65 = R"doc(Convenience method returning the standard D65 illuminant.)doc";
 
 static const char *__doc_mitsuba_Texture_Texture = R"doc()doc";
@@ -7722,6 +7550,8 @@ static const char *__doc_mitsuba_Volume = R"doc(Abstract base class for spatiall
 static const char *__doc_mitsuba_Volume_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Volume_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_Volume_4 = R"doc()doc";
 
 static const char *__doc_mitsuba_VolumeMetadata =
 R"doc(Holds metadata about a volume, e.g. when loaded from a Mitsuba binary
@@ -8343,29 +8173,6 @@ static const char *__doc_mitsuba_hasher_operator_call = R"doc()doc";
 
 static const char *__doc_mitsuba_ior_from_file = R"doc()doc";
 
-static const char *__doc_mitsuba_kensler_permute =
-R"doc(Generate pseudorandom permutation vector using the algorithm described
-in Pixar's technical memo "Correlated Multi-Jittered Sampling":
-
-https://graphics.pixar.com/library/MultiJitteredSampling/
-
-Unlike permute, this function supports permutation vectors of any
-length.
-
-Parameter ``index``:
-    Input index to be mapped
-
-Parameter ``sample_count``:
-    Length of the permutation vector
-
-Parameter ``seed``:
-    Seed value used as second input to the Tiny Encryption Algorithm.
-    Can be used to generate different permutation vectors.
-
-Returns:
-    The index corresponding to the input index in the pseudorandom
-    permutation vector.)doc";
-
 static const char *__doc_mitsuba_librender_nop =
 R"doc(Dummy function which can be called to ensure that the librender shared
 library is loaded)doc";
@@ -8885,10 +8692,6 @@ Returns:
     The (implicitly defined) reference coordinate system basis for the
     Stokes vector travelling along w.)doc";
 
-static const char *__doc_mitsuba_next_float =
-R"doc(Forward next_float call to PCG32 random generator based given type
-size)doc";
-
 static const char *__doc_mitsuba_operator_add = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_add_2 = R"doc(Adding a vector to a point should always yield a point)doc";
@@ -9009,10 +8812,6 @@ static const char *__doc_mitsuba_operator_sub = R"doc(Subtracting two points sho
 
 static const char *__doc_mitsuba_operator_sub_2 = R"doc(Subtracting a vector from a point should always yield a point)doc";
 
-static const char *__doc_mitsuba_optix_initialize = R"doc(Try to load the OptiX library)doc";
-
-static const char *__doc_mitsuba_optix_shutdown = R"doc()doc";
-
 static const char *__doc_mitsuba_parse_fov = R"doc(Helper function to parse the field of view field of a camera)doc";
 
 static const char *__doc_mitsuba_pdf_rgb_spectrum =
@@ -9030,8 +8829,6 @@ the PDF is returned per wavelength.)doc";
 static const char *__doc_mitsuba_pdf_uniform_spectrum = R"doc()doc";
 
 static const char *__doc_mitsuba_pdf_uniform_spectrum_2 = R"doc()doc";
-
-static const char *__doc_mitsuba_perspective_projection = R"doc()doc";
 
 static const char *__doc_mitsuba_permute =
 R"doc(Generate pseudorandom permutation vector using a shuffling network and
@@ -9056,6 +8853,31 @@ Parameter ``rounds``:
 Returns:
     The index corresponding to the input index in the pseudorandom
     permutation vector.)doc";
+
+static const char *__doc_mitsuba_permute_kensler =
+R"doc(Generate pseudorandom permutation vector using the algorithm described
+in Pixar's technical memo "Correlated Multi-Jittered Sampling":
+
+https://graphics.pixar.com/library/MultiJitteredSampling/
+
+Unlike permute, this function supports permutation vectors of any
+length.
+
+Parameter ``index``:
+    Input index to be mapped
+
+Parameter ``sample_count``:
+    Length of the permutation vector
+
+Parameter ``seed``:
+    Seed value used as second input to the Tiny Encryption Algorithm.
+    Can be used to generate different permutation vectors.
+
+Returns:
+    The index corresponding to the input index in the pseudorandom
+    permutation vector.)doc";
+
+static const char *__doc_mitsuba_perspective_projection = R"doc()doc";
 
 static const char *__doc_mitsuba_profiler_flags = R"doc()doc";
 
@@ -9188,9 +9010,11 @@ static const char *__doc_mitsuba_ref_ref = R"doc(Create a ``nullptr``-valued ref
 
 static const char *__doc_mitsuba_ref_ref_2 = R"doc(Construct a reference from a pointer)doc";
 
-static const char *__doc_mitsuba_ref_ref_3 = R"doc(Copy constructor)doc";
+static const char *__doc_mitsuba_ref_ref_3 = R"doc(Construct a reference from another convertible reference)doc";
 
-static const char *__doc_mitsuba_ref_ref_4 = R"doc(Move constructor)doc";
+static const char *__doc_mitsuba_ref_ref_4 = R"doc(Copy constructor)doc";
+
+static const char *__doc_mitsuba_ref_ref_5 = R"doc(Move constructor)doc";
 
 static const char *__doc_mitsuba_reflect = R"doc(Reflection in local coordinates)doc";
 
@@ -9219,10 +9043,6 @@ Parameter ``eta_ti``:
     Relative index of refraction (transmitted / incident))doc";
 
 static const char *__doc_mitsuba_round_to_packet_size = R"doc(Round an integer to a multiple of the current packet size)doc";
-
-static const char *__doc_mitsuba_rt_check = R"doc()doc";
-
-static const char *__doc_mitsuba_rt_check_log = R"doc()doc";
 
 static const char *__doc_mitsuba_sample_rgb_spectrum =
 R"doc(Importance sample a "importance spectrum" that concentrates the

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -4496,6 +4496,8 @@ static const char *__doc_mitsuba_ProfilerPhase_SampleEmitterDirection = R"doc()d
 
 static const char *__doc_mitsuba_ProfilerPhase_SampleEmitterRay = R"doc()doc";
 
+static const char *__doc_mitsuba_ProfilerPhase_SamplerSeed = R"doc()doc";
+
 static const char *__doc_mitsuba_ProfilerPhase_SamplingIntegratorSample = R"doc()doc";
 
 static const char *__doc_mitsuba_ProfilerPhase_TextureEvaluate = R"doc()doc";
@@ -4921,6 +4923,24 @@ static const char *__doc_mitsuba_RadicalInverse_scramble = R"doc(Return the orig
 
 static const char *__doc_mitsuba_RadicalInverse_to_string = R"doc(Return a human-readable string representation)doc";
 
+static const char *__doc_mitsuba_RandomSampler = R"doc()doc";
+
+static const char *__doc_mitsuba_RandomSampler_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_RandomSampler_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_RandomSampler_RandomSampler = R"doc()doc";
+
+static const char *__doc_mitsuba_RandomSampler_check_rng = R"doc()doc";
+
+static const char *__doc_mitsuba_RandomSampler_class = R"doc()doc";
+
+static const char *__doc_mitsuba_RandomSampler_m_rng = R"doc()doc";
+
+static const char *__doc_mitsuba_RandomSampler_seed = R"doc()doc";
+
+static const char *__doc_mitsuba_RandomSampler_wavefront_size = R"doc()doc";
+
 static const char *__doc_mitsuba_Ray =
 R"doc(Simple n-dimensional ray segment data structure
 
@@ -5164,9 +5184,15 @@ static const char *__doc_mitsuba_Sampler_m_base_seed = R"doc()doc";
 
 static const char *__doc_mitsuba_Sampler_m_sample_count = R"doc()doc";
 
+static const char *__doc_mitsuba_Sampler_m_samples_per_wavefront = R"doc()doc";
+
+static const char *__doc_mitsuba_Sampler_m_wavefront_count = R"doc()doc";
+
 static const char *__doc_mitsuba_Sampler_next_1d = R"doc(Retrieve the next component value from the current sample)doc";
 
 static const char *__doc_mitsuba_Sampler_next_2d = R"doc(Retrieve the next two component values from the current sample)doc";
+
+static const char *__doc_mitsuba_Sampler_prepare_wavefront = R"doc(Start the next wavefront)doc";
 
 static const char *__doc_mitsuba_Sampler_sample_count = R"doc(Return the number of samples per pixel)doc";
 
@@ -5176,6 +5202,10 @@ R"doc(Deterministically seed the underlying RNG, if applicable.
 In the context of wavefront ray tracing & dynamic arrays, this
 function must be called with a ``seed_value`` matching the size of the
 wavefront.)doc";
+
+static const char *__doc_mitsuba_Sampler_set_samples_per_wavefront =
+R"doc(Set the number of samples per pass in the wavefront modes (default is
+1))doc";
 
 static const char *__doc_mitsuba_Sampler_wavefront_size = R"doc(Return the size of the wavefront (or 0, if not seeded))doc";
 
@@ -8313,6 +8343,29 @@ static const char *__doc_mitsuba_hasher_operator_call = R"doc()doc";
 
 static const char *__doc_mitsuba_ior_from_file = R"doc()doc";
 
+static const char *__doc_mitsuba_kensler_permute =
+R"doc(Generate pseudorandom permutation vector using the algorithm described
+in Pixar's technical memo "Correlated Multi-Jittered Sampling":
+
+https://graphics.pixar.com/library/MultiJitteredSampling/
+
+Unlike permute, this function supports permutation vectors of any
+length.
+
+Parameter ``index``:
+    Input index to be mapped
+
+Parameter ``sample_count``:
+    Length of the permutation vector
+
+Parameter ``seed``:
+    Seed value used as second input to the Tiny Encryption Algorithm.
+    Can be used to generate different permutation vectors.
+
+Returns:
+    The index corresponding to the input index in the pseudorandom
+    permutation vector.)doc";
+
 static const char *__doc_mitsuba_librender_nop =
 R"doc(Dummy function which can be called to ensure that the librender shared
 library is loaded)doc";
@@ -8832,6 +8885,10 @@ Returns:
     The (implicitly defined) reference coordinate system basis for the
     Stokes vector travelling along w.)doc";
 
+static const char *__doc_mitsuba_next_float =
+R"doc(Forward next_float call to PCG32 random generator based given type
+size)doc";
+
 static const char *__doc_mitsuba_operator_add = R"doc()doc";
 
 static const char *__doc_mitsuba_operator_add_2 = R"doc(Adding a vector to a point should always yield a point)doc";
@@ -8976,6 +9033,30 @@ static const char *__doc_mitsuba_pdf_uniform_spectrum_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_perspective_projection = R"doc()doc";
 
+static const char *__doc_mitsuba_permute =
+R"doc(Generate pseudorandom permutation vector using a shuffling network and
+the sample_tea function. This algorithm has a O(log2(sample_count))
+complexity but only supports permutation vectors whose lengths are a
+power of 2.
+
+Parameter ``index``:
+    Input index to be mapped
+
+Parameter ``sample_count``:
+    Length of the permutation vector
+
+Parameter ``seed``:
+    Seed value used as second input to the Tiny Encryption Algorithm.
+    Can be used to generate different permutation vectors.
+
+Parameter ``rounds``:
+    How many rounds should be executed by the Tiny Encryption
+    Algorithm? The default is 2.
+
+Returns:
+    The index corresponding to the input index in the pseudorandom
+    permutation vector.)doc";
+
 static const char *__doc_mitsuba_profiler_flags = R"doc()doc";
 
 static const char *__doc_mitsuba_quad_composite_simpson =
@@ -9054,6 +9135,8 @@ Parameter ``n``:
 Returns:
     A tuple (nodes, weights) storing the nodes and weights of the
     quadrature rule.)doc";
+
+static const char *__doc_mitsuba_radical_inverse_2 = R"doc(Van der Corput radical inverse in base 2)doc";
 
 static const char *__doc_mitsuba_ref =
 R"doc(Reference counting helper
@@ -9274,6 +9357,8 @@ Parameter ``si``:
     A surface intersection record (usually on an emitter).
 
 \note Defined in scene.h)doc";
+
+static const char *__doc_mitsuba_sobol_2 = R"doc(Sobol' radical inverse in base 2)doc";
 
 static const char *__doc_mitsuba_spectrum_from_file = R"doc()doc";
 

--- a/include/mitsuba/render/integrator.h
+++ b/include/mitsuba/render/integrator.h
@@ -158,7 +158,8 @@ protected:
                               Sampler *sampler,
                               ImageBlock *block,
                               Float *aovs,
-                              size_t sample_count = size_t(-1)) const;
+                              size_t sample_count,
+                              size_t block_id) const;
 
     void render_sample(const Scene *scene,
                        const Sensor *sensor,

--- a/include/mitsuba/render/sampler.h
+++ b/include/mitsuba/render/sampler.h
@@ -8,13 +8,14 @@
 #include <mitsuba/core/random.h>
 
 NAMESPACE_BEGIN(mitsuba)
+
 /**
  * \brief Base class of all sample generators.
  *
  * For each sample in a pixel, a sample generator produces a (hypothetical)
  * point in the infinite dimensional random number cube. A rendering
  * algorithm can then request subsequent 1D or 2D components of this point
- * using the \ref next_1d() and \ref next_2d() functions.
+ * using the \c next_1d and \c next_2d functions.
  *
  * Scalar and wavefront rendering algorithms will need interact with the sampler
  * interface in a slightly different way:
@@ -73,7 +74,7 @@ public:
     /**
      * \brief Advance to the next sample.
      *
-     * A subsequent call to \ref next_1d() or \ref next_2d() will access the first
+     * A subsequent call to \c next_1d or \c next_2d will access the first
      * 1D or 2D components of this sample.
      */
     virtual void advance();

--- a/include/mitsuba/render/sampler.h
+++ b/include/mitsuba/render/sampler.h
@@ -5,9 +5,45 @@
 #include <mitsuba/core/logger.h>
 #include <mitsuba/core/object.h>
 #include <mitsuba/core/vector.h>
+#include <mitsuba/core/random.h>
 
 NAMESPACE_BEGIN(mitsuba)
-
+/**
+ * \brief Base class of all sample generators.
+ *
+ * For each sample in a pixel, a sample generator produces a (hypothetical)
+ * point in the infinite dimensional random number cube. A rendering
+ * algorithm can then request subsequent 1D or 2D components of this point
+ * using the \ref next_1d() and \ref next_2d() functions.
+ *
+ * Scalar and wavefront rendering algorithms will need interact with the sampler
+ * interface in a slightly different way:
+ *
+ * Scalar rendering algorithm:
+ *
+ *   1. Before beginning to render a pixel block, the rendering algorithm calls
+ *      \c seed to initialize a new sequence with the specific seed offset.
+ *   2. The first pixel sample can now be computed, after which \c advance needs to be
+ *      invoked. This repeats until all pixel samples have been generated. Note that some
+ *      implementations need to be configured for a certain number of pixel samples, and
+ *      exceeding these will lead to an exception being thrown.
+ *   3. While computing a pixel sample, the rendering algorithm usually requests batches
+ *      of (pseudo-) random numbers using the \c next_1d and \c next_2d functions
+ *      before moving on to the next sample.
+ *
+ * Wavefront rendering algorithm:
+ *
+ *   1. Before beginning to render the wavefront, the rendering algorithm needs to inform the
+ *      sampler of the amount of samples rendered in parallel for every pixel in the wavefront.
+ *      This can be achieved by calling \c set_samples_per_wavefront .
+ *   2. Then the rendering algorithm should seed the sampler and set the appropriate wavefront
+ *      size by calling \c seed. A different seed value, based on the \c base_seed and
+ *      the seed offset, will be used for every sample (of every pixel) in the wavefront.
+ *   3. \c advance can be used to advance to the next sample in the sequence.
+ *   4. As in the scalar approach, the rendering algorithm can request batches of (pseudo-)
+ *      random numbers using the \c next_1d and \c next_2d functions.
+ *
+ */
 template <typename Float, typename Spectrum>
 class MTS_EXPORT_RENDER Sampler : public Object {
 public:
@@ -30,9 +66,17 @@ public:
      * \brief Deterministically seed the underlying RNG, if applicable.
      *
      * In the context of wavefront ray tracing & dynamic arrays, this function
-     * must be called with a \c seed_value matching the size of the wavefront.
+     * must be called with \c wavefront_size matching the size of the wavefront.
      */
-    virtual void seed(UInt64 seed_value);
+    virtual void seed(uint64_t seed_offset, size_t wavefront_size = 1);
+
+    /**
+     * \brief Advance to the next sample.
+     *
+     * A subsequent call to \ref next_1d() or \ref next_2d() will access the first
+     * 1D or 2D components of this sample.
+     */
+    virtual void advance();
 
     /// Retrieve the next component value from the current sample
     virtual Float next_1d(Mask active = true);
@@ -41,20 +85,60 @@ public:
     virtual Point2f next_2d(Mask active = true);
 
     /// Return the number of samples per pixel
-    size_t sample_count() const { return m_sample_count; }
+    uint32_t sample_count() const { return m_sample_count; }
 
     /// Return the size of the wavefront (or 0, if not seeded)
-    virtual size_t wavefront_size() const = 0;
+    uint32_t wavefront_size() const { return m_wavefront_size; };
+
+    /// Return whether the sampler was seeded
+    bool seeded() const { return m_wavefront_size > 0; }
+
+    /// Set the number of samples per pass in wavefront modes (default is 1)
+    void set_samples_per_wavefront(uint32_t samples_per_wavefront);
 
     MTS_DECLARE_CLASS()
 protected:
     Sampler(const Properties &props);
     virtual ~Sampler();
 
+    /// Generates a array of seeds where the seed values are unique per sequence
+    UInt32 compute_per_sequence_seed(uint32_t seed_offset) const;
+    /// Return the index of the current sample
+    UInt32 current_sample_index() const;
+
 protected:
-    size_t m_sample_count;
-    ScalarUInt64 m_base_seed;
+    /// Base seed value
+    uint64_t m_base_seed;
+    /// Number of samples per pixel
+    uint32_t m_sample_count;
+    /// Number of samples per pass in wavefront modes (default is 1)
+    uint32_t m_samples_per_wavefront;
+    /// Size of the wavefront (or 0, if not seeded)
+    uint32_t m_wavefront_size;
+    /// Index of the current dimension in the sample
+    uint32_t m_dimension_index;
+    /// Index of the current sample in the sequence
+    uint32_t m_sample_index;
+};
+
+/// Interface for sampler plugins based on the PCG32 random number generator
+template <typename Float, typename Spectrum>
+class MTS_EXPORT_RENDER PCG32Sampler : public Sampler<Float, Spectrum> {
+public:
+    MTS_IMPORT_BASE(Sampler, m_base_seed)
+    MTS_IMPORT_TYPES()
+    using PCG32 = mitsuba::PCG32<UInt32>;
+
+    virtual void seed(uint64_t seed_offset, size_t wavefront_size = 1) override;
+
+    MTS_DECLARE_CLASS()
+protected:
+    PCG32Sampler(const Properties &props);
+
+protected:
+    PCG32 m_rng;
 };
 
 MTS_EXTERN_CLASS_RENDER(Sampler)
+MTS_EXTERN_CLASS_RENDER(PCG32Sampler)
 NAMESPACE_END(mitsuba)

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -45,7 +45,7 @@ def generate_fixture(variant):
 
 for variant in ['scalar_rgb', 'scalar_spectral',
                 'scalar_mono_polarized', 'packet_rgb',
-                'packet_spectral', 'gpu_autodiff_rgb']:
+                'packet_spectral', 'gpu_rgb', 'gpu_autodiff_rgb']:
     generate_fixture(variant)
 del generate_fixture
 

--- a/src/libcore/python/qmc_v.cpp
+++ b/src/libcore/python/qmc_v.cpp
@@ -23,4 +23,10 @@ MTS_PY_EXPORT(qmc) {
              D(RadicalInverse, permutation))
         .def("inverse_permutation", &RadicalInverse::inverse_permutation,
              D(RadicalInverse, inverse_permutation));
+
+    m.def("radical_inverse_2", vectorize(radical_inverse_2<UInt32>),
+          "index"_a, "scramble"_a, D(radical_inverse_2));
+
+    m.def("sobol_2", vectorize(sobol_2<UInt32>),
+          "index"_a, "scramble"_a, D(sobol_2));
 }

--- a/src/libcore/python/random_v.cpp
+++ b/src/libcore/python/random_v.cpp
@@ -3,6 +3,10 @@
 
 MTS_PY_EXPORT(sample_tea) {
     MTS_PY_IMPORT_TYPES()
+    m.def("sample_tea_32",
+          vectorize(sample_tea_32<UInt32>),
+          "v0"_a, "v1"_a, "rounds"_a = 4, D(sample_tea_32));
+
     m.def("sample_tea_float32",
           vectorize(sample_tea_float32<UInt32>),
           "v0"_a, "v1"_a, "rounds"_a = 4, D(sample_tea_float32));
@@ -13,4 +17,12 @@ MTS_PY_EXPORT(sample_tea) {
 
     m.attr("sample_tea_float") = m.attr(
         sizeof(Float) != sizeof(Float64) ? "sample_tea_float32" : "sample_tea_float64");
+
+    m.def("permute",
+          vectorize(permute<UInt32>),
+          "value"_a, "sample_count"_a, "seed"_a, "rounds"_a = 4, D(permute));
+
+    m.def("permute_kensler",
+          vectorize(permute_kensler<UInt32>),
+          "i"_a, "l"_a, "p"_a, "active"_a = true, D(permute_kensler));
 }

--- a/src/libcore/tests/test_random.py
+++ b/src/libcore/tests/test_random.py
@@ -3,7 +3,7 @@ import pytest
 import mitsuba
 
 
-def test_tea_float32(variant_scalar_rgb):
+def test01_tea_float32(variant_scalar_rgb):
     from mitsuba.core import sample_tea_float32
 
     assert sample_tea_float32(1, 1, 4) == 0.5424730777740479
@@ -16,7 +16,7 @@ def test_tea_float32(variant_scalar_rgb):
     assert sample_tea_float32(4, 1, 4) == 0.4897364377975464
 
 
-def test_tea_float64(variant_scalar_rgb):
+def test02_tea_float64(variant_scalar_rgb):
     from mitsuba.core import sample_tea_float64
 
     assert sample_tea_float64(1, 1, 4) == 0.5424730799533735
@@ -29,7 +29,7 @@ def test_tea_float64(variant_scalar_rgb):
     assert sample_tea_float64(4, 1, 4) == 0.48973647949223253
 
 
-def test_tea_vectorized(variant_packet_rgb):
+def test03_tea_vectorized(variant_packet_rgb):
     from mitsuba.core import sample_tea_float32, sample_tea_float64, UInt32
 
     count = 100
@@ -45,3 +45,67 @@ def test_tea_vectorized(variant_packet_rgb):
         UInt32.arange(count), 4)
     for i in range(count):
         assert result[i] == sample_tea_float64(1, i, 4)
+
+
+def test04_permute_bijection(variant_scalar_rgb):
+    """ Check that the resulting permutation vectors are bijections """
+    from mitsuba.core import permute
+
+    for p in range(4):
+        sample_count = 2**(p+1)
+        for seed in range(500):
+            perm = [permute(i, sample_count, seed) for i in range(sample_count)]
+            assert len(set(perm)) == len(perm)
+
+
+def test05_permute_uniform(variant_scalar_rgb):
+    """ Chi2 tests to check that the permutation vectors are uniformly distributed """
+    import numpy as np
+    from mitsuba.core import permute
+
+    for p in range(4):
+        sample_count = 2**(p+1)
+        histogram = np.zeros((sample_count, sample_count))
+
+        N = 1000
+        for seed in range(N):
+            for i in range(sample_count):
+                j = permute(i, sample_count, seed)
+                histogram[i, j] += 1
+
+        histogram /= N
+
+        mean = np.mean(histogram)
+        assert ek.allclose(1.0 / sample_count, mean)
+
+
+def test06_permute_kensler_bijection(variant_scalar_rgb, variant_gpu_rgb):
+    """ Check that the resulting permutation vectors are bijections """
+    from mitsuba.core import permute_kensler
+
+    for p in range(4):
+        sample_count = 2**(p+1) + p
+        for seed in range(500):
+            perm = [permute_kensler(i, sample_count, seed) for i in range(sample_count)]
+            assert len(set(perm)) == len(perm)
+
+
+def test07_permute_kensler_uniform(variant_scalar_rgb):
+    """ Chi2 tests to check that the permutation vectors are uniformly distributed """
+    import numpy as np
+    from mitsuba.core import permute_kensler
+
+    for p in range(4):
+        sample_count = 2**(p+1) + p
+        histogram = np.zeros((sample_count, sample_count))
+
+        N = 1000
+        for seed in range(N):
+            for i in range(sample_count):
+                j = permute_kensler(i, sample_count, seed)
+                histogram[i, j] += 1
+
+        histogram /= N
+
+        mean = np.mean(histogram)
+        assert ek.allclose(1.0 / sample_count, mean)

--- a/src/librender/python/sampler_v.cpp
+++ b/src/librender/python/sampler_v.cpp
@@ -7,8 +7,10 @@ MTS_PY_EXPORT(Sampler) {
         .def_method(Sampler, clone)
         .def_method(Sampler, sample_count)
         .def_method(Sampler, wavefront_size)
+        .def("set_samples_per_wavefront", &Sampler::set_samples_per_wavefront )
         .def("seed", vectorize(&Sampler::seed),
-             "seed_value"_a, D(Sampler, seed))
+             "seed_offset"_a, "wavefront_size"_a = 1, D(Sampler, seed))
+        .def("advance", &Sampler::advance)
         .def("next_1d", vectorize(&Sampler::next_1d),
              "active"_a = true, D(Sampler, next_1d))
         .def("next_2d", vectorize(&Sampler::next_2d),

--- a/src/librender/python/sampler_v.cpp
+++ b/src/librender/python/sampler_v.cpp
@@ -7,10 +7,10 @@ MTS_PY_EXPORT(Sampler) {
         .def_method(Sampler, clone)
         .def_method(Sampler, sample_count)
         .def_method(Sampler, wavefront_size)
-        .def("set_samples_per_wavefront", &Sampler::set_samples_per_wavefront )
+        .def_method(Sampler, set_samples_per_wavefront, "samples_per_wavefront"_a)
+        .def_method(Sampler, advance)
         .def("seed", vectorize(&Sampler::seed),
              "seed_offset"_a, "wavefront_size"_a = 1, D(Sampler, seed))
-        .def("advance", &Sampler::advance)
         .def("next_1d", vectorize(&Sampler::next_1d),
              "active"_a = true, D(Sampler, next_1d))
         .def("next_2d", vectorize(&Sampler::next_2d),

--- a/src/librender/sampler.cpp
+++ b/src/librender/sampler.cpp
@@ -1,23 +1,106 @@
 #include <mitsuba/render/sampler.h>
 #include <mitsuba/core/properties.h>
+#include <mitsuba/core/profiler.h>
 
 NAMESPACE_BEGIN(mitsuba)
+
+// =======================================================================
+//! @{ \name Sampler implementations
+// =======================================================================
 
 MTS_VARIANT Sampler<Float, Spectrum>::Sampler(const Properties &props) {
     m_sample_count = props.size_("sample_count", 4);
     m_base_seed = props.size_("seed", 0);
+
+    m_dimension_index = 0u;
+    m_sample_index = 0;
+    m_samples_per_wavefront = 1;
+    m_wavefront_size = 0;
 }
 
 MTS_VARIANT Sampler<Float, Spectrum>::~Sampler() { }
 
-MTS_VARIANT void Sampler<Float, Spectrum>::seed(UInt64) { NotImplementedError("seed"); }
+MTS_VARIANT void Sampler<Float, Spectrum>::seed(uint64_t /*seed_offset*/,
+                                                size_t wavefront_size) {
+    m_wavefront_size = wavefront_size;
+    m_dimension_index = 0u;
+    m_sample_index = 0;
+}
 
-MTS_VARIANT Float Sampler<Float, Spectrum>::next_1d(Mask) { NotImplementedError("next_1d"); }
+MTS_VARIANT void Sampler<Float, Spectrum>::advance() {
+    m_dimension_index = 0u;
+    m_sample_index++;
+    Assert(m_sample_index < (m_sample_count / m_samples_per_wavefront));
+}
 
-MTS_VARIANT typename Sampler<Float, Spectrum>::Point2f Sampler<Float, Spectrum>::next_2d(Mask) {
+MTS_VARIANT Float Sampler<Float, Spectrum>::next_1d(Mask) {
+    NotImplementedError("next_1d");
+}
+
+MTS_VARIANT typename Sampler<Float, Spectrum>::Point2f
+Sampler<Float, Spectrum>::next_2d(Mask) {
     NotImplementedError("next_2d");
 }
 
+MTS_VARIANT void
+Sampler<Float, Spectrum>::set_samples_per_wavefront(uint32_t samples_per_wavefront) {
+    if constexpr (is_scalar_v<Float>)
+        Throw("set_samples_per_wavefront should not be used in scalar variants of the renderer.");
+
+    m_samples_per_wavefront = samples_per_wavefront;
+    if (m_sample_count % m_samples_per_wavefront != 0)
+        Throw("sample_count should be a multiple of samples_per_wavefront!");
+}
+
+MTS_VARIANT typename Sampler<Float, Spectrum>::UInt32
+Sampler<Float, Spectrum>::compute_per_sequence_seed(uint32_t seed_offset) const {
+    UInt32 indices = arange<UInt32>(m_wavefront_size);
+    UInt32 sequence_idx = m_samples_per_wavefront * (indices / m_samples_per_wavefront);
+    return sample_tea_32(UInt32(m_base_seed), sequence_idx + UInt32(seed_offset));
+}
+
+
+MTS_VARIANT typename Sampler<Float, Spectrum>::UInt32
+Sampler<Float, Spectrum>::current_sample_index() const {
+    // Build an array of offsets for the sample indices in the wavefront
+    UInt32 wavefront_sample_offsets = 0;
+    if (m_samples_per_wavefront > 1)
+        wavefront_sample_offsets = arange<UInt32>(m_wavefront_size) % m_samples_per_wavefront;
+
+    return m_sample_index * m_samples_per_wavefront + wavefront_sample_offsets;
+}
+
+//! @}
+// =======================================================================
+
+// =======================================================================
+//! @{ \name PCG32Sampler implementations
+// =======================================================================
+
+MTS_VARIANT PCG32Sampler<Float, Spectrum>::PCG32Sampler(const Properties &props)
+    : Base(props) {}
+
+MTS_VARIANT void PCG32Sampler<Float, Spectrum>::seed(uint64_t seed_offset,
+                                                     size_t wavefront_size) {
+    Base::seed(seed_offset, wavefront_size);
+
+    uint64_t seed_value = m_base_seed + seed_offset;
+
+    if constexpr (is_dynamic_array_v<Float>) {
+        UInt64 idx = arange<UInt64>(wavefront_size);
+        m_rng.seed(sample_tea_64(UInt64(seed_value), idx),
+                   sample_tea_64(idx, UInt64(seed_value)));
+    } else {
+        m_rng.seed(seed_value, PCG32_DEFAULT_STREAM + arange<UInt64>());
+    }
+}
+
+//! @}
+// =======================================================================
+
 MTS_IMPLEMENT_CLASS_VARIANT(Sampler, Object, "sampler")
+MTS_IMPLEMENT_CLASS_VARIANT(PCG32Sampler, Sampler, "PCG32 sampler")
+
 MTS_INSTANTIATE_CLASS(Sampler)
+MTS_INSTANTIATE_CLASS(PCG32Sampler)
 NAMESPACE_END(mitsuba)

--- a/src/python/python/autodiff.py
+++ b/src/python/python/autodiff.py
@@ -22,7 +22,7 @@ def _render_helper(scene, spp=None, sensor_index=0):
     total_sample_count = ek.hprod(film_size) * spp
 
     if sampler.wavefront_size() != total_sample_count:
-        sampler.seed(ek.arange(UInt64, total_sample_count))
+        sampler.seed(0, total_sample_count)
 
     pos = ek.arange(UInt32, total_sample_count)
     pos //= spp

--- a/src/samplers/CMakeLists.txt
+++ b/src/samplers/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(MTS_PLUGIN_PREFIX "samplers")
 
 add_plugin(independent  independent.cpp)
+add_plugin(stratified   stratified.cpp)
+add_plugin(multijitter  multijitter.cpp)
+add_plugin(orthogonal   orthogonal.cpp)
+add_plugin(ldsampler    ldsampler.cpp)
 
 # Register the test directory
 add_tests(${CMAKE_CURRENT_SOURCE_DIR}/tests)

--- a/src/samplers/independent.cpp
+++ b/src/samplers/independent.cpp
@@ -1,5 +1,5 @@
+#include <mitsuba/core/profiler.h>
 #include <mitsuba/core/properties.h>
-#include <mitsuba/core/random.h>
 #include <mitsuba/core/spectrum.h>
 #include <mitsuba/render/sampler.h>
 
@@ -28,20 +28,33 @@ by Melissa O’Neill.
 
 This is the most basic sample generator; because no precautions are taken to avoid
 sample clumping, images produced using this plugin will usually take longer to converge.
-In theory, this sampler is initialized using a deterministic procedure, which means
-that subsequent runs of Mitsuba should create the same image. In practice, when
-rendering with multiple threads and/or machines, this is not true anymore, since the
-ordering of samples is influenced by the operating system scheduler.
+Looking at the figures below where samples are projected onto a 2D unit square, we see that there
+are both regions that don't receive many samples (i.e. we don't know much about the behavior of
+the function there), and regions where many samples are very close together (which likely have very
+similar values), which will result in higher variance in the rendered image.
+
+This sampler is initialized using a deterministic procedure, which means that subsequent runs
+of Mitsuba should create the same image. In practice, when rendering with multiple threads
+and/or machines, this is not true anymore, since the ordering of samples is influenced by the
+operating system scheduler. Although these should be absolutely negligible, with relative errors
+on the order of the machine epsilon (:math:`6\cdot 10^{-8}`) in single precision.
+
+.. subfigstart::
+.. subfigure:: ../../resources/data/docs/images/sampler/independent_1024_samples.svg
+   :caption: 1024 samples projected onto the first two dimensions.
+.. subfigure:: ../../resources/data/docs/images/sampler/independent_64_samples_and_proj.svg
+   :caption: 64 samples projected onto the first two dimensions and their
+             projection on both 1D axis (top and right plot).
+.. subfigend::
+   :label: fig-independent-pattern
 
  */
 
 template <typename Float, typename Spectrum>
-class IndependentSampler final : public Sampler<Float, Spectrum> {
+class IndependentSampler final : public PCG32Sampler<Float, Spectrum> {
 public:
-    MTS_IMPORT_BASE(Sampler, m_sample_count, m_base_seed)
+    MTS_IMPORT_BASE(PCG32Sampler, m_sample_count, m_base_seed, m_rng, seed, seeded)
     MTS_IMPORT_TYPES()
-
-    using PCG32 = mitsuba::PCG32<UInt32>;
 
     IndependentSampler(const Properties &props = Properties()) : Base(props) {
         /* Can't seed yet on the GPU because we don't know yet
@@ -50,55 +63,22 @@ public:
             seed(PCG32_DEFAULT_STATE);
     }
 
-    ref<Base> clone() override {
+    ref<Sampler<Float, Spectrum>> clone() override {
         IndependentSampler *sampler = new IndependentSampler();
         sampler->m_sample_count = m_sample_count;
         sampler->m_base_seed = m_base_seed;
         return sampler;
     }
 
-    /// Seeds the RNG with the specified size, if applicable
-    void seed(UInt64 seed_value) override {
-        if (!m_rng)
-            m_rng = std::make_unique<PCG32>();
-
-        seed_value += m_base_seed;
-
-        if constexpr (is_dynamic_array_v<Float>) {
-            UInt64 idx = arange<UInt64>(seed_value.size());
-            m_rng->seed(sample_tea_64(seed_value, idx),
-                        sample_tea_64(idx, seed_value));
-        } else {
-            m_rng->seed(seed_value, PCG32_DEFAULT_STREAM + arange<UInt64>());
-        }
-    }
-
     Float next_1d(Mask active = true) override {
-        if constexpr (is_dynamic_array_v<Float>) {
-            if (m_rng == nullptr)
-                Throw("Sampler::seed() must be invoked before using this sampler!");
-            if (active.size() != 1 && active.size() != m_rng->state.size())
-                Throw("Invalid mask size (%d), expected %d", active.size(), m_rng->state.size());
-        }
-
-        if constexpr (is_double_v<ScalarFloat>)
-            return m_rng->next_float64(active);
-        else
-            return m_rng->next_float32(active);
+        Assert(seeded());
+        return m_rng.template next_float<Float>(active);
     }
 
     Point2f next_2d(Mask active = true) override {
         Float f1 = next_1d(active),
               f2 = next_1d(active);
         return Point2f(f1, f2);
-    }
-
-    /// Return the size of the wavefront (or 0, if not seeded)
-    size_t wavefront_size() const override {
-        if (m_rng == nullptr)
-            return 0;
-        else
-            return enoki::slices(m_rng->state);
     }
 
     std::string to_string() const override {
@@ -110,8 +90,6 @@ public:
     }
 
     MTS_DECLARE_CLASS()
-protected:
-    std::unique_ptr<PCG32> m_rng;
 };
 
 MTS_IMPLEMENT_CLASS_VARIANT(IndependentSampler, Sampler)

--- a/src/samplers/ldsampler.cpp
+++ b/src/samplers/ldsampler.cpp
@@ -1,0 +1,143 @@
+#include <mitsuba/core/profiler.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/spectrum.h>
+#include <mitsuba/core/qmc.h>
+#include <mitsuba/render/sampler.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _sampler-ldsampler:
+
+Low discrepancy sampler (:monosp:`ldsampler`)
+---------------------------------------------
+
+This plugin implements a simple hybrid sampler that combines aspects of a Quasi-Monte Carlo sequence
+with a pseudorandom number generator based on a technique proposed by Kollig and Keller
+:cite:`Kollig2002Efficient`. It is a good and fast general-purpose sample generator. Other QMC
+samplers exist that can generate even better distributed samples, but this comes at a higher
+cost in terms of performance. This plugin is based on Mitsuba 1's default sampler (also called
+:monosp:`ldsampler`).
+
+Roughly, the idea of this sampler is that all of the individual 2D sample dimensions are first
+filled using the same (0, 2)-sequence, which is then randomly scrambled and permuted using a
+shuffle network. The name of this plugin stems from the fact that, by construction,
+(0, 2)-sequences achieve a low
+`star discrepancy <https://en.wikipedia.org/wiki/Low-discrepancy_sequence>`_,
+which is a quality criterion on their spatial distribution.
+
+.. subfigstart::
+.. subfigure:: ../../resources/data/docs/images/render/sampler_independent_16spp.jpg
+   :caption: Independent sampler - 16 samples per pixel
+.. subfigure:: ../../resources/data/docs/images/render/sampler_ldsampler_16spp.jpg
+   :caption: Low-discrepancy sampler - 16 samples per pixel
+.. subfigend::
+   :label: fig-ldsampler-renders
+
+.. subfigstart::
+.. subfigure:: ../../resources/data/docs/images/sampler/ldsampler_1024_samples.svg
+   :caption: 1024 samples projected onto the first two dimensions.
+.. subfigure:: ../../resources/data/docs/images/sampler/ldsampler_64_samples_and_proj.svg
+   :caption: A projection of the first 64 samples onto the first two dimensions and their
+             projection on both 1D axis (top and right plot). The 1D stratification is perfect as
+             this sampler doesn't add additional random perturbation to the sample positions.
+.. subfigend::
+   :label: fig-ldsampler-pattern
+
+.. subfigstart::
+.. subfigure:: ../../resources/data/docs/images/sampler/ldsampler_1024_samples_dim_32.svg
+   :caption: 1024 samples projected onto the 32th and 33th dimensions, which look almost identical.
+             However, note that the points have been scrambled to reduce correlations between
+             dimensions.
+.. subfigure:: ../../resources/data/docs/images/sampler/ldsampler_64_samples_and_proj_dim_32.svg
+   :caption: A projection of the first 64 samples onto the 32th and 33th dimensions.
+.. subfigend::
+   :label: fig-ldsampler-pattern_dim32
+
+ */
+
+template <typename Float, typename Spectrum>
+class LowDiscrepancySampler  final : public Sampler<Float, Spectrum> {
+public:
+    MTS_IMPORT_BASE(Sampler, m_sample_count, m_base_seed, seeded,
+                    m_samples_per_wavefront, m_dimension_index,
+                    current_sample_index, compute_per_sequence_seed)
+    MTS_IMPORT_TYPES()
+
+    LowDiscrepancySampler (const Properties &props = Properties()) : Base(props) {
+        // Make sure sample_count is power of two and square (e.g. 4, 16, 64, 256, 1024, ...)
+        ScalarUInt32 res = 2;
+        while (sqr(res) < m_sample_count)
+            res = math::round_to_power_of_two(++res);
+
+        if (m_sample_count != sqr(res))
+            Log(Warn, "Sample count should be square and power of two, rounding to %i", sqr(res));
+
+        m_sample_count = sqr(res);
+    }
+
+    ref<Sampler<Float, Spectrum>> clone() override {
+        LowDiscrepancySampler  *sampler  = new LowDiscrepancySampler ();
+        sampler->m_sample_count          = m_sample_count;
+        sampler->m_samples_per_wavefront = m_samples_per_wavefront;
+        sampler->m_base_seed             = m_base_seed;
+        return sampler;
+    }
+
+    void seed(uint64_t seed_offset, size_t wavefront_size) override {
+        Base::seed(seed_offset, wavefront_size);
+        m_scramble_seed = compute_per_sequence_seed(seed_offset);
+    }
+
+    Float next_1d(Mask /*active*/ = true) override {
+        Assert(seeded());
+
+        UInt32 sample_indices = current_sample_index();
+        UInt32 perm_seed = m_scramble_seed + m_dimension_index++;
+
+        // Shuffle the samples order
+        UInt32 i = permute(sample_indices, m_sample_count, perm_seed);
+
+        // Compute scramble value (unique per sequence)
+        UInt32 scramble = sample_tea_32(m_scramble_seed, UInt32(0x48bc48eb));
+
+        return radical_inverse_2(i, scramble);
+    }
+
+    Point2f next_2d(Mask /*active*/ = true) override {
+        Assert(seeded());
+
+        UInt32 sample_indices = current_sample_index();
+        UInt32 perm_seed = m_scramble_seed + m_dimension_index++;
+
+        // Shuffle the samples order
+        UInt32 i = permute(sample_indices, m_sample_count, perm_seed);
+
+        // Compute scramble values (unique per sequence) for both axis
+        UInt32 scramble_x = sample_tea_32(m_scramble_seed, UInt32(0x98bc51ab));
+        UInt32 scramble_y = sample_tea_32(m_scramble_seed, UInt32(0x04223e2d));
+
+        Float x = radical_inverse_2(i, scramble_x),
+              y = sobol_2(i, scramble_y);
+
+        return Point2f(x, y);
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "LowDiscrepancySampler [" << std::endl
+            << "  sample_count = " << m_sample_count << std::endl
+            << "]";
+        return oss.str();
+    }
+
+    MTS_DECLARE_CLASS()
+private:
+    /// Per-sequence scramble seed
+    UInt32 m_scramble_seed;
+};
+
+MTS_IMPLEMENT_CLASS_VARIANT(LowDiscrepancySampler , Sampler)
+MTS_EXPORT_PLUGIN(LowDiscrepancySampler , "Low Discrepancy Sampler");
+NAMESPACE_END(mitsuba)

--- a/src/samplers/multijitter.cpp
+++ b/src/samplers/multijitter.cpp
@@ -1,0 +1,171 @@
+#include <mitsuba/core/profiler.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/spectrum.h>
+#include <mitsuba/render/sampler.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _sampler-multijitter:
+
+Correlated Multi-Jittered sampler (:monosp:`multijitter`)
+---------------------------------------------------------
+
+.. pluginparameters::
+
+ * - sample_count
+   - |int|
+   - Number of samples per pixel. The sampler may internally choose to slightly increase this
+     value to create a subdivision into strata that has an aspect ratio close to one. (Default: 4)
+ * - seed
+   - |int|
+   - Seed offset (Default: 0)
+ * - jitter
+   - |bool|
+   - Adds additional random jitter withing the substratum (Default: True)
+
+This plugin implements the methods introduced in Pixar's tech memo :cite:`kensler1967correlated`.
+
+Unlike the previously described stratified sampler, multi-jittered sample patterns produce samples
+that are well stratified in 2D but also well stratified when projected onto one dimension. This can
+greatly reduce the variance of a Monte-Carlo estimator when the function to evaluate exhibits more
+variation along one axis of the sampling domain than the other.
+
+This sampler achieves this by first placing samples in a canonical arrangement that is stratified in
+both 2D and 1D. It then shuffles the x-coordinate of the samples in every columns and the
+y-coordinate in every rows. Fortunately, this process doesn't break the 2D and 1D stratification.
+Kensler's method futher reduces sample clumpiness by correlating the shuffling applied to the
+columns and the rows.
+
+.. subfigstart::
+.. subfigure:: ../../resources/data/docs/images/render/sampler_independent_16spp.jpg
+   :caption: Independent sampler - 16 samples per pixel
+.. subfigure:: ../../resources/data/docs/images/render/sampler_multijitter_16spp.jpg
+   :caption: Correlated Multi-Jittered sampler - 16 samples per pixel
+.. subfigend::
+   :label: fig-multijitter-renders
+
+.. subfigstart::
+.. subfigure:: ../../resources/data/docs/images/sampler/multijitter_1024_samples.svg
+   :caption: 1024 samples projected onto the first two dimensions.
+.. subfigure:: ../../resources/data/docs/images/sampler/multijitter_64_samples_and_proj.svg
+   :caption: 64 samples projected onto the first two dimensions and their projection on both 1D axis
+             (top and right plot). As expected, the samples are well stratified both in 2D and 1D.
+.. subfigend::
+   :label: fig-multijitter-pattern
+
+ */
+
+template <typename Float, typename Spectrum>
+class MultijitterSampler final : public PCG32Sampler<Float, Spectrum> {
+public:
+    MTS_IMPORT_BASE(PCG32Sampler, m_sample_count, m_base_seed, m_rng, seeded,
+                    m_samples_per_wavefront, m_dimension_index,
+                    current_sample_index, compute_per_sequence_seed)
+    MTS_IMPORT_TYPES()
+
+    MultijitterSampler(const Properties &props = Properties()) : Base(props) {
+        m_jitter = props.bool_("jitter", true);
+
+        // Find stratification grid resolution with aspect ratio close to 1
+        m_resolution[1] = uint32_t(sqrt(ScalarFloat(m_sample_count)));
+        m_resolution[0] = (m_sample_count + m_resolution[1] - 1) / m_resolution[1];
+
+        if (m_sample_count != hprod(m_resolution))
+            Log(Warn, "Sample count rounded up to %i", hprod(m_resolution));
+
+        m_sample_count = hprod(m_resolution);
+        m_inv_sample_count = rcp(ScalarFloat(m_sample_count));
+        m_inv_resolution   = rcp(ScalarPoint2f(m_resolution));
+        m_resolution_x_div = m_resolution[0];
+    }
+
+    ref<Sampler<Float, Spectrum>> clone() override {
+        MultijitterSampler *sampler = new MultijitterSampler();
+        sampler->m_jitter                = m_jitter;
+        sampler->m_sample_count          = m_sample_count;
+        sampler->m_inv_sample_count      = m_inv_sample_count;
+        sampler->m_resolution            = m_resolution;
+        sampler->m_inv_resolution        = m_inv_resolution;
+        sampler->m_resolution_x_div      = m_resolution_x_div;
+        sampler->m_samples_per_wavefront = m_samples_per_wavefront;
+        sampler->m_base_seed             = m_base_seed;
+        return sampler;
+    }
+
+    void seed(uint64_t seed_offset, size_t wavefront_size) override {
+        Base::seed(seed_offset, wavefront_size);
+        m_permutation_seed = compute_per_sequence_seed(seed_offset);
+    }
+
+    Float next_1d(Mask active = true) override {
+        Assert(seeded());
+
+        UInt32 sample_indices = current_sample_index();
+        UInt32 perm_seed = m_permutation_seed + m_dimension_index++;
+
+        // Shuffle the samples order
+        Float p = permute_kensler(sample_indices, m_sample_count, perm_seed * 0x45fbe943, active);
+
+        // Add a random perturbation
+        Float j = m_jitter ? m_rng.template next_float<Float>(active) : 0.5f;
+
+        return (p + j) * m_inv_sample_count;
+    }
+
+    Point2f next_2d(Mask active = true) override {
+        Assert(seeded());
+
+        UInt32 sample_indices = current_sample_index();
+        UInt32 perm_seed = m_permutation_seed + m_dimension_index++;
+
+        // Shuffle the samples order
+        UInt32 s = permute_kensler(sample_indices, m_sample_count, perm_seed * 0x51633e2d, active);
+
+        // Map the index to its 2D cell
+        UInt32 y = m_resolution_x_div(s);    // s / m_resolution.x()
+        UInt32 x = s - y * m_resolution.x(); // s % m_resolution.x()
+
+        // Compute offsets to the appropriate substratum within the cell
+        UInt32 sx = permute_kensler(x, m_resolution.x(), perm_seed * 0x68bc21eb, active);
+        UInt32 sy = permute_kensler(y, m_resolution.y(), perm_seed * 0x02e5be93, active);
+
+        // Add random perturbations on both axis
+        Float jx = 0.5f, jy = 0.5f;
+        if (m_jitter) {
+            jx = m_rng.template next_float<Float>(active);
+            jy = m_rng.template next_float<Float>(active);
+        }
+
+        // Construct the final 2D point
+        return Point2f((x + (sy + jx) * m_inv_resolution.y()) * m_inv_resolution.x(),
+                       (y + (sx + jy) * m_inv_resolution.x()) * m_inv_resolution.y());
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "MultijitterSampler[" << std::endl
+            << "  sample_count = " << m_sample_count << std::endl
+            << "  jitter = " << m_jitter << std::endl
+            << "]";
+        return oss.str();
+    }
+
+    MTS_DECLARE_CLASS()
+private:
+    bool m_jitter;
+
+    /// Stratification grid resolution and precomputed variables
+    ScalarPoint2u m_resolution;
+    ScalarPoint2f m_inv_resolution;
+    ScalarFloat m_inv_sample_count;
+    enoki::divisor<uint32_t> m_resolution_x_div;
+
+    /// Per-sequence permutation seed
+    UInt32 m_permutation_seed;
+};
+
+MTS_IMPLEMENT_CLASS_VARIANT(MultijitterSampler, Sampler)
+MTS_EXPORT_PLUGIN(MultijitterSampler, "Correlated Multi-Jittered Sampler");
+NAMESPACE_END(mitsuba)

--- a/src/samplers/orthogonal.cpp
+++ b/src/samplers/orthogonal.cpp
@@ -1,0 +1,234 @@
+#include <mitsuba/core/profiler.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/spectrum.h>
+#include <mitsuba/render/sampler.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _sampler-orthogonal:
+
+Orthogonal Array sampler (:monosp:`orthogonal`)
+-----------------------------------------------
+
+.. pluginparameters::
+
+ * - sample_count
+   - |int|
+   - Number of samples per pixel. This value has to be the square of a prime number. (Default: 4)
+ * - strength
+   - |int|
+   - Orthogonal array's strength (Default: 2)
+ * - seed
+   - |int|
+   - Seed offset (Default: 0)
+ * - jitter
+   - |bool|
+   - Adds additional random jitter withing the substratum (Default: True)
+
+This plugin implements the Orthogonal Array sampler generator introduced by Jarosz et al.
+:cite:`jarosz19orthogonal`. It generalizes correlated multi-jittered sampling to higher dimensions
+by using *orthogonal arrays (OAs)*. An OA of strength :math:`s` has the property that projecting
+the generated samples to any combination of :math:`s` dimensions will always result in a well
+stratified pattern. In other words, when :math:`s=2` (default value), the high-dimentional samples
+are simultaneously stratified in all 2D projections as if they had been produced by correlated
+multi-jittered sampling. By construction, samples produced by this generator are also well
+stratified when projected on both 1D axis.
+
+This sampler supports OA of strength other than 2, although this isn't recommended as the
+stratification of 2D projections of those samples wouldn't be ensured anymore.
+
+.. subfigstart::
+.. subfigure:: ../../resources/data/docs/images/render/sampler_independent_25spp.jpg
+   :caption: Independent sampler - 25 samples per pixel
+.. subfigure:: ../../resources/data/docs/images/render/sampler_orthogonal_25spp.jpg
+   :caption: Orthogonal Array sampler - 25 samples per pixel
+.. subfigend::
+   :label: fig-orthogonal-renders
+
+.. subfigstart::
+.. subfigure:: ../../resources/data/docs/images/sampler/orthogonal_1369_samples.svg
+   :caption: 1369 samples projected onto the first two dimensions.
+.. subfigure:: ../../resources/data/docs/images/sampler/orthogonal_49_samples_and_proj.svg
+   :caption: 49 samples projected onto the first two dimensions and their
+             projection on both 1D axis (top and right plot). The pattern is well stratified
+             in both 2D and 1D projections. This is true for every pair of dimensions of the
+             high-dimentional samples.
+.. subfigend::
+   :label: fig-orthogonal-pattern
+
+ */
+
+template <typename Float, typename Spectrum>
+class OrthogonalSampler final : public PCG32Sampler<Float, Spectrum> {
+public:
+    MTS_IMPORT_BASE(PCG32Sampler, m_sample_count, m_base_seed, m_rng, seeded,
+                    m_samples_per_wavefront, m_dimension_index,
+                    current_sample_index, compute_per_sequence_seed)
+    MTS_IMPORT_TYPES()
+
+    OrthogonalSampler(const Properties &props = Properties()) : Base(props) {
+        m_jitter = props.bool_("jitter", true);
+        m_strength = props.int_("strength", 2);
+
+        // Make sure m_resolution is a prime number
+        auto is_prime = [](uint32_t x) {
+            for (uint32_t i = 2; i <= x / 2; ++i)
+                if (x % i == 0)
+                    return false;
+            return true;
+        };
+
+        m_resolution = 2;
+        while (sqr(m_resolution) < m_sample_count || !is_prime(m_resolution))
+            m_resolution++;
+
+        if (m_sample_count != sqr(m_resolution))
+            Log(Warn, "Sample count should be the square of a prime"
+                "number, rounding to %i", sqr(m_resolution));
+
+        m_sample_count = sqr(m_resolution);
+        m_resolution_div = m_resolution;
+    }
+
+    ref<Sampler<Float, Spectrum>> clone() override {
+        OrthogonalSampler *sampler       = new OrthogonalSampler();
+        sampler->m_jitter                = m_jitter;
+        sampler->m_strength              = m_strength;
+        sampler->m_sample_count          = m_sample_count;
+        sampler->m_resolution            = m_resolution;
+        sampler->m_resolution_div        = m_resolution_div;
+        sampler->m_samples_per_wavefront = m_samples_per_wavefront;
+        sampler->m_base_seed             = m_base_seed;
+        return sampler;
+    }
+
+    void seed(uint64_t seed_offset, size_t wavefront_size) override {
+        Base::seed(seed_offset, wavefront_size);
+        m_permutation_seed = compute_per_sequence_seed(seed_offset);
+    }
+
+    Float next_1d(Mask active = true) override {
+        Assert(seeded());
+
+        if (unlikely(m_strength != 2)) {
+            return bush(current_sample_index(),
+                        m_dimension_index++,
+                        m_permutation_seed, active);
+        } else {
+            return bose(current_sample_index(),
+                        m_dimension_index++,
+                        m_permutation_seed, active);
+        }
+    }
+
+    Point2f next_2d(Mask active = true) override {
+        Float f1 = next_1d(active),
+              f2 = next_1d(active);
+        return Point2f(f1, f2);
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "OrthogonalSampler[" << std::endl
+            << "  sample_count = " << m_sample_count << std::endl
+            << "  jitter = " << m_jitter << std::endl
+            << "]";
+        return oss.str();
+    }
+
+    MTS_DECLARE_CLASS()
+
+private:
+    /// Compute the digits of decimal value \ref i expressed in base \ref m_strength
+    std::vector<UInt32> to_base_s(UInt32 i) {
+        std::vector<UInt32> digits(m_strength);
+        UInt32 tmp = i;
+        for (size_t ii = 0; ii < m_strength; i = m_resolution_div(i), ++ii) {
+            digits[ii] = tmp - i * m_resolution; // i % m_resolution
+            tmp = i;
+        }
+        return digits;
+    }
+
+    /// Evaluate polynomial with coefficients \ref x at location arg
+    UInt32 eval_poly(const std::vector<UInt32> &coef, UInt32 x) {
+        UInt32 res = 0;
+        for (size_t l = coef.size(); l--; )
+            res = (res * x) + coef[l];
+        return res;
+    }
+
+    /// Bush construction technique for orthogonal arrays
+    Float bush(UInt32 i,   // sample index
+               uint32_t j, // dimension
+               UInt32 p,   // pseudo-random permutation seed
+               Mask active = true) {
+        uint32_t N = enoki::pow(m_resolution, int(m_strength));
+        uint32_t stm = m_resolution_div(N);
+
+        // Convert the permuted sample index to base strength
+        i = permute_kensler(i, N, p, active);
+        auto i_digits = to_base_s(i);
+
+        // Reinterpret those difits as a base-j number (evaluate the polynomial)
+        UInt32 phi = eval_poly(i_digits, j);
+
+        // Multi-jitter flavor with random perturbation
+        UInt32 stratum = permute_kensler(phi % m_resolution, m_resolution, p * (j + 1) * 0x51633e2d, active);
+        UInt32 sub_stratum = permute_kensler((i / m_resolution) % stm, stm, p * (j + 1) * 0x68bc21eb, active);
+        Float jitter = m_jitter ? m_rng.template next_float<Float>(active) : 0.5f;
+        return (stratum + (sub_stratum + jitter) / stm) / m_resolution;
+    }
+
+    /// Bose construction technique for orthogonal arrays. It only support OA of strength == 2
+    Float bose(UInt32 i,   // sample index
+               uint32_t j, // dimension
+               UInt32 p,   // pseudo-random permutation seed
+               Mask active = true) {
+
+        // Permute the sample index so that samples are obtained in random order
+        i = permute_kensler(i % m_sample_count, m_sample_count, p, active);
+
+        // Map a linear index into a regular 2D grid
+        UInt32 a_i0 = m_resolution_div(i);     // i / m_resolution
+        UInt32 a_i1 = i - a_i0 * m_resolution; // i % m_resolution
+
+        // Bose construction scheme
+        UInt32 a_ij, a_ik;
+        if (j == 0) {
+            a_ij = a_i0;
+            a_ik = a_i1;
+        } else if (j == 1) {
+            a_ij = a_i1;
+            a_ik = a_i0;
+        } else {
+            /// Linear combination of the 2D mapping (modulo the grid resolution)
+            UInt32 k = (j % 2) ? j - 1 : j + 1;
+            a_ij = (a_i0 + (j - 1) * a_i1) % m_resolution;
+            a_ik = (a_i0 + (k - 1) * a_i1) % m_resolution;
+        }
+
+        // Correlated multi-jitter flavor with random perturbation
+        UInt32 stratum     = permute_kensler(a_ij, m_resolution, p * (j + 1) * 0x51633e2d, active);
+        UInt32 sub_stratum = permute_kensler(a_ik, m_resolution, p * (j + 1) * 0x68bc21eb, active);
+        Float jitter = m_jitter ? m_rng.template next_float<Float>(active) : 0.5f;
+        return (stratum + (sub_stratum + jitter) / m_resolution) / m_resolution;
+    }
+
+private:
+    bool m_jitter;
+    uint32_t m_strength;
+
+    /// Stratification grid resolution
+    uint32_t m_resolution;
+    enoki::divisor<uint32_t> m_resolution_div;
+
+    /// Per-sequence permutation seed
+    UInt32 m_permutation_seed;
+};
+
+MTS_IMPLEMENT_CLASS_VARIANT(OrthogonalSampler, Sampler)
+MTS_EXPORT_PLUGIN(OrthogonalSampler, "Orthogonal Array Sampler");
+NAMESPACE_END(mitsuba)

--- a/src/samplers/stratified.cpp
+++ b/src/samplers/stratified.cpp
@@ -1,0 +1,160 @@
+#include <mitsuba/core/profiler.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/spectrum.h>
+#include <mitsuba/render/sampler.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _sampler-stratified:
+
+Stratified sampler (:monosp:`stratified`)
+-------------------------------------------
+
+.. pluginparameters::
+
+ * - sample_count
+   - |int|
+   - Number of samples per pixel. This number should be a square number (Default: 4)
+ * - seed
+   - |int|
+   - Seed offset (Default: 0)
+ * - jitter
+   - |bool|
+   - Adds additional random jitter withing the stratum (Default: True)
+
+The stratified sample generator divides the domain into a discrete number of strata and produces
+a sample within each one of them. This generally leads to less sample clumping when compared to
+the independent sampler, as well as better convergence.
+
+.. subfigstart::
+.. subfigure:: ../../resources/data/docs/images/render/sampler_independent_16spp.jpg
+   :caption: Independent sampler - 16 samples per pixel
+.. subfigure:: ../../resources/data/docs/images/render/sampler_stratified_16spp.jpg
+   :caption: Stratified sampler - 16 samples per pixel
+.. subfigend::
+   :label: fig-stratified-renders
+
+.. subfigstart::
+.. subfigure:: ../../resources/data/docs/images/sampler/stratified_1024_samples.svg
+   :caption: 1024 samples projected onto the first two dimensions which are well distributed
+             if we compare to the :monosp:`independent` sampler.
+.. subfigure:: ../../resources/data/docs/images/sampler/stratified_64_samples_and_proj.svg
+   :caption: 64 samples projected in 2D and on both 1D axis (top and right plot). Every strata
+             contains a single sample creating a good distribution when projected in 2D. Projections
+             on both 1D axis still exhibit sample clumping which will result in higher variance, for
+             instance when sampling a thin streched rectangular area light.
+.. subfigend::
+   :label: fig-stratified-pattern
+
+ */
+
+template <typename Float, typename Spectrum>
+class StratifiedSampler final : public PCG32Sampler<Float, Spectrum> {
+public:
+    MTS_IMPORT_BASE(PCG32Sampler, m_sample_count, m_base_seed, m_rng, seeded,
+                    m_samples_per_wavefront, m_dimension_index,
+                    current_sample_index, compute_per_sequence_seed)
+    MTS_IMPORT_TYPES()
+
+    StratifiedSampler(const Properties &props = Properties()) : Base(props) {
+        m_jitter = props.bool_("jitter", true);
+
+        // Make sure sample_count is a square number
+        m_resolution = 1;
+        while (sqr(m_resolution) < m_sample_count)
+            m_resolution++;
+
+        if (m_sample_count != sqr(m_resolution))
+            Log(Warn, "Sample count should be square and power of two, rounding to %i", sqr(m_resolution));
+
+        m_sample_count = sqr(m_resolution);
+        m_inv_sample_count = rcp(ScalarFloat(m_sample_count));
+        m_inv_resolution   = rcp(ScalarFloat(m_resolution));
+        m_resolution_div = m_resolution;
+    }
+
+    ref<Sampler<Float, Spectrum>> clone() override {
+        StratifiedSampler *sampler = new StratifiedSampler();
+        sampler->m_jitter                = m_jitter;
+        sampler->m_sample_count          = m_sample_count;
+        sampler->m_inv_sample_count      = m_inv_sample_count;
+        sampler->m_resolution            = m_resolution;
+        sampler->m_inv_resolution        = m_inv_resolution;
+        sampler->m_resolution_div        = m_resolution_div;
+        sampler->m_samples_per_wavefront = m_samples_per_wavefront;
+        sampler->m_base_seed             = m_base_seed;
+        return sampler;
+    }
+
+    void seed(uint64_t seed_offset, size_t wavefront_size) override {
+        Base::seed(seed_offset, wavefront_size);
+        m_permutation_seed = compute_per_sequence_seed(seed_offset);
+    }
+
+    Float next_1d(Mask active = true) override {
+        Assert(seeded());
+
+        UInt32 sample_indices = current_sample_index();
+        UInt32 perm_seed = m_permutation_seed + m_dimension_index++;
+
+        // Shuffle the samples order
+        UInt32 p = permute_kensler(sample_indices, m_sample_count, perm_seed, active);
+
+        // Add a random perturbation
+        Float j = m_jitter ? m_rng.template next_float<Float>(active) : 0.5f;
+
+        return (p + j) * m_inv_sample_count;
+    }
+
+    Point2f next_2d(Mask active = true) override {
+        Assert(seeded());
+
+        UInt32 sample_indices = current_sample_index();
+        UInt32 perm_seed = m_permutation_seed + m_dimension_index++;
+
+        // Shuffle the samples order
+        UInt32 p = permute_kensler(sample_indices, m_sample_count, perm_seed, active);
+
+        // Map the index to its 2D cell
+        UInt32 y = m_resolution_div(p);  // p / m_resolution
+        UInt32 x = p - y * m_resolution; // p % m_resolution
+
+        // Add a random perturbation
+        Float jx = 0.5f, jy = 0.5f;
+        if (m_jitter) {
+            jx = m_rng.template next_float<Float>(active);
+            jy = m_rng.template next_float<Float>(active);
+        }
+
+        // Construct the final 2D point
+        return Point2f(x + jx, y + jy) * m_inv_resolution;
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "StratifiedSampler[" << std::endl
+            << "  sample_count = " << m_sample_count << std::endl
+            << "  jitter = " << m_jitter << std::endl
+            << "]";
+        return oss.str();
+    }
+
+    MTS_DECLARE_CLASS()
+private:
+    bool m_jitter;
+
+    /// Stratification grid resolution
+    ScalarUInt32 m_resolution;
+    ScalarFloat m_inv_resolution;
+    ScalarFloat m_inv_sample_count;
+    enoki::divisor<ScalarUInt32> m_resolution_div;
+
+    /// Per-sequence permutation seed
+    UInt32 m_permutation_seed;
+};
+
+MTS_IMPLEMENT_CLASS_VARIANT(StratifiedSampler, Sampler)
+MTS_EXPORT_PLUGIN(StratifiedSampler, "Stratified Sampler");
+NAMESPACE_END(mitsuba)

--- a/src/samplers/tests/test_independent.py
+++ b/src/samplers/tests/test_independent.py
@@ -41,25 +41,3 @@ def test03_clone(variant_scalar_rgb, sampler):
     for i in range(5):
         assert ek.all(sampler.next_1d() != sampler2.next_1d())
         assert ek.all(sampler.next_2d() != sampler2.next_2d())
-
-
-def test04_seed_vectorized(variant_scalar_rgb, sampler):
-    """For a given seed, the first lane of a sampled packet should be equal
-    to the sample of a scalar independent sampler."""
-
-    try:
-        mitsuba.set_variant('packet_rgb')
-    except:
-        pytest.skip("packet_rgb mode not enabled")
-
-    from mitsuba.core.xml import load_string
-
-    sampler_p = load_string("""<sampler version="2.0.0" type="independent">
-                <integer name="sample_count" value="%d"/>
-            </sampler>""" % 8)
-
-    for seed in range(10):
-        sampler.seed(seed)
-        sampler_p.seed(seed)
-        assert sampler.next_1d() == sampler_p.next_1d()[0]
-        assert ek.allclose(sampler_p.next_2d(), ek.dynamic.Vector2f(sampler.next_2d()))

--- a/src/samplers/tests/test_ldsampler.py
+++ b/src/samplers/tests/test_ldsampler.py
@@ -1,0 +1,66 @@
+import mitsuba
+import pytest
+import enoki as ek
+import numpy as np
+
+from .utils import check_uniform_scalar_sampler, check_uniform_wavefront_sampler
+
+def test01_ldsampler_scalar(variant_scalar_rgb):
+    from mitsuba.core import xml
+
+    sampler = xml.load_dict({
+        "type" : "ldsampler",
+        "sample_count" : 1024,
+    })
+
+    check_uniform_scalar_sampler(sampler)
+
+
+def test02_ldsampler_wavefront(variant_gpu_rgb):
+    from mitsuba.core import xml
+
+    sampler = xml.load_dict({
+        "type" : "ldsampler",
+        "sample_count" : 1024,
+    })
+
+    check_uniform_wavefront_sampler(sampler)
+
+
+def test03_ldsampler_deterministic_values(variant_scalar_rgb):
+    from mitsuba.core import xml
+
+    sampler = xml.load_dict({
+        "type" : "ldsampler",
+        "sample_count" : 1024,
+    })
+
+    sampler.seed(0)
+
+    values_1d_dim0 = [0.1091986894, 0.0291205644, 0.8533393144, 0.3924018144, 0.6511908769,
+                      0.9900580644, 0.7781440019, 0.2771674394, 0.4353705644, 0.3601752519]
+
+    values_2d_dim0 = [[0.09034, 0.975105], [0.332528, 0.576667], [0.521004, 0.88819],
+                      [0.00244939, 0.0629952], [0.182137, 0.367683], [0.679207, 0.296394],
+                      [0.0219806, 0.137214], [0.308113, 0.995612], [0.548348, 0.579597]]
+
+    values_1d_dim1 = [0.934394001, 0.534003376, 0.258612751, 0.856269001, 0.279120564, 0.434394001,
+                      0.235175251, 0.654120564, 0.811347126, 0.958808064]
+
+    values_2d_dim1 = [[0.771981, 0.387214], [0.732918, 0.113776], [0.0708088, 0.791511],
+                      [0.966317, 0.849128], [0.959481, 0.199714], [0.392098, 0.985847],
+                      [0.767098, 0.860847], [0.989754, 0.98194], [0.0932697, 0.726081]]
+
+    for v in values_1d_dim0:
+        assert ek.allclose(sampler.next_1d(), v)
+
+    for v in values_2d_dim0:
+        assert ek.allclose(sampler.next_2d(), v)
+
+    sampler.advance()
+
+    for v in values_1d_dim1:
+        assert ek.allclose(sampler.next_1d(), v)
+
+    for v in values_2d_dim1:
+        assert ek.allclose(sampler.next_2d(), v)

--- a/src/samplers/tests/test_multijitter.py
+++ b/src/samplers/tests/test_multijitter.py
@@ -1,0 +1,27 @@
+import mitsuba
+import pytest
+import enoki as ek
+import numpy as np
+
+from .utils import check_uniform_scalar_sampler, check_uniform_wavefront_sampler
+
+def test01_multijitter_scalar(variant_scalar_rgb):
+    from mitsuba.core import xml
+
+    sampler = xml.load_dict({
+        "type" : "multijitter",
+        "sample_count" : 1024,
+    })
+
+    check_uniform_scalar_sampler(sampler)
+
+
+def test02_multijitter_wavefront(variant_gpu_rgb):
+    from mitsuba.core import xml
+
+    sampler = xml.load_dict({
+        "type" : "multijitter",
+        "sample_count" : 1024,
+    })
+
+    check_uniform_wavefront_sampler(sampler)

--- a/src/samplers/tests/test_orthogonal.py
+++ b/src/samplers/tests/test_orthogonal.py
@@ -1,0 +1,27 @@
+import mitsuba
+import pytest
+import enoki as ek
+import numpy as np
+
+from .utils import check_uniform_scalar_sampler, check_uniform_wavefront_sampler
+
+def test01_orthogonal_scalar(variant_scalar_rgb):
+    from mitsuba.core import xml
+
+    sampler = xml.load_dict({
+        "type" : "orthogonal",
+        "sample_count" : 1369,
+    })
+
+    check_uniform_scalar_sampler(sampler, res=4, atol=4.0)
+
+
+def test02_orthogonal_wavefront(variant_gpu_rgb):
+    from mitsuba.core import xml
+
+    sampler = xml.load_dict({
+        "type" : "orthogonal",
+        "sample_count" : 1369,
+    })
+
+    check_uniform_wavefront_sampler(sampler, atol=4.0)

--- a/src/samplers/tests/test_stratified.py
+++ b/src/samplers/tests/test_stratified.py
@@ -1,0 +1,27 @@
+import mitsuba
+import pytest
+import enoki as ek
+import numpy as np
+
+from .utils import check_uniform_scalar_sampler, check_uniform_wavefront_sampler
+
+def test01_stratified_scalar(variant_scalar_rgb):
+    from mitsuba.core import xml
+
+    sampler = xml.load_dict({
+        "type" : "stratified",
+        "sample_count" : 1024,
+    })
+
+    check_uniform_scalar_sampler(sampler)
+
+
+def test02_stratified_wavefront(variant_gpu_rgb):
+    from mitsuba.core import xml
+
+    sampler = xml.load_dict({
+        "type" : "stratified",
+        "sample_count" : 1024,
+    })
+
+    check_uniform_wavefront_sampler(sampler)

--- a/src/samplers/tests/utils.py
+++ b/src/samplers/tests/utils.py
@@ -1,0 +1,53 @@
+import mitsuba
+import pytest
+import enoki as ek
+import numpy as np
+
+def check_uniform_scalar_sampler(sampler, res=16, atol=0.5):
+    sampler.seed(0)
+    sample_count = sampler.sample_count()
+
+    hist_1d = np.zeros(res)
+    hist_2d = np.zeros((res, res))
+
+    for i in range(sample_count):
+        v_1d = sampler.next_1d()
+        hist_1d[int(v_1d * res)] += 1
+        v_2d = sampler.next_2d()
+        hist_2d[int(v_2d.x * res), int(v_2d.y * res)] += 1
+        sampler.advance()
+
+    # print(hist_1d)
+    # print(hist_2d)
+
+    assert ek.allclose(hist_1d, float(sample_count) / res, atol=atol)
+    assert ek.allclose(hist_2d, float(sample_count) / (res * res), atol=atol)
+
+
+def check_uniform_wavefront_sampler(sampler, res=16, atol=0.5):
+    from mitsuba.core import Float, UInt32, UInt64, Vector2u
+
+    sample_count = sampler.sample_count()
+    sampler.set_samples_per_wavefront(sample_count)
+
+    sampler.seed(0, sample_count)
+
+    hist_1d = ek.zero(UInt32, res)
+    hist_2d = ek.zero(UInt32, res * res)
+
+    v_1d = ek.clamp(sampler.next_1d() * res, 0, res)
+    ek.scatter_add(
+        target=hist_1d,
+        index=UInt32(v_1d),
+        source=UInt32(1.0)
+    )
+
+    v_2d = Vector2u(ek.clamp(sampler.next_2d() * res, 0, res))
+    ek.scatter_add(
+        target=hist_2d,
+        index=UInt32(v_2d.x * res + v_2d.y),
+        source=UInt32(1.0)
+    )
+
+    assert ek.allclose(Float(hist_1d), float(sample_count) / res, atol=atol)
+    assert ek.allclose(Float(hist_2d), float(sample_count) / (res * res), atol=atol)


### PR DESCRIPTION
## Implementation of various `sampler` plugins

This PR provides implementation for various sampler plugins:

- `stratified`
- `multijitter` (from [Correlated Multi-jitter sampling](https://graphics.pixar.com/library/MultiJitteredSampling/))
- `ldsampler` (ported from Mitsuba 1)
- `orthogonal` (from [Orthogonal Array Sampling for Monte Carlo Rendering](https://cs.dartmouth.edu/~wjarosz/publications/jarosz19orthogonal.html))

This PR also update the doc API.