### PR TITLE
Update doc to remove shape support on GPU

### DIFF
--- a/src/shapes/cylinder.cpp
+++ b/src/shapes/cylinder.cpp
@@ -69,9 +69,6 @@ A simple example for instantiating a cylinder, whose interior is visible:
             <bsdf type="diffuse"/>
         </bsdf>
     </shape>
-
-.. warning:: This plugin is currently not supported by the OptiX raytracing backend.
-
  */
 
 template <typename Float, typename Spectrum>

--- a/src/shapes/disk.cpp
+++ b/src/shapes/disk.cpp
@@ -62,9 +62,6 @@ The following XML snippet instantiates an example of a textured disk shape:
             </texture>
         </bsdf>
     </shape>
-
-.. warning:: This plugin is currently not supported by the OptiX raytracing backend.
-
  */
 
 template <typename Float, typename Spectrum>

--- a/src/shapes/rectangle.cpp
+++ b/src/shapes/rectangle.cpp
@@ -62,9 +62,6 @@ The following XML snippet showcases a simple example of a textured rectangle:
             </texture>
         </bsdf>
     </shape>
-
-.. warning:: This plugin is currently not supported by the OptiX raytracing backend.
-
  */
 
 template <typename Float, typename Spectrum>

--- a/src/shapes/sphere.cpp
+++ b/src/shapes/sphere.cpp
@@ -83,10 +83,6 @@ This makes it a good default choice for lighting new scenes.
    :caption: Spherical area light modeled using the :ref:`sphere <shape-sphere>` plugin
 .. subfigend::
    :label: fig-sphere-light
-
-
-.. warning:: This plugin is currently not supported by the OptiX raytracing backend.
-
  */
 
 template <typename Float, typename Spectrum>


### PR DESCRIPTION
Removes warning from primitive shapes as they are now supported using Optix