### PR TITLE
Sensor tests to load_dict

### DIFF
--- a/src/sensors/tests/test_perspective.py
+++ b/src/sensors/tests/test_perspective.py
@@ -3,31 +3,36 @@ import pytest
 import enoki as ek
 
 
-def create_camera(o, d, fov=34, fov_axis='x', s_open=1.5, s_close=5):
-    from mitsuba.core.xml import load_string
-    return load_string("""<sensor version='2.0.0' type='perspective'>
-                              <float name='near_clip' value='1'/>
-                              <float name='far_clip' value='35'/>
-                              <float name='focus_distance' value='15'/>
-                              <float name='fov' value='{fov}'/>
-                              <string name='fov_axis' value='{fov_axis}'/>
-                              <float name='shutter_open' value='{so}'/>
-                              <float name='shutter_close' value='{sc}'/>
-                              <transform name="to_world">
-                                  <lookat origin="{ox}, {oy}, {oz}"
-                                          target="{tx}, {ty}, {tz}"
-                                          up    =" 0.0,  1.0,  0.0"/>
-                              </transform>
-                              <film type="hdrfilm">
-                                  <integer name="width" value="512"/>
-                                  <integer name="height" value="256"/>
-                              </film>
-                          </sensor> """.format(ox=o[0], oy=o[1], oz=o[2],
-                                               tx=o[0]+d[0], ty=o[1]+d[1], tz=o[2]+d[2],
-                                               fov=fov, fov_axis=fov_axis, so=s_open, sc=s_close))
+def create_camera(o, d, fov=34, fov_axis="x", s_open=1.5, s_close=5):
+    from mitsuba.core.xml import load_dict
+    from mitsuba.core import ScalarTransform4f, ScalarVector3f
+    t = [o[0] + d[0], o[1] + d[1], o[2] + d[2]]
+
+    camera_dict = {
+        "type": "perspective",
+        "near_clip": 1.0,
+        "far_clip": 35.0,
+        "focus_distance": 15.0,
+        "fov": fov,
+        "fov_axis": fov_axis,
+        "shutter_open": s_open, 
+        "shutter_close": s_close,
+        "to_world": ScalarTransform4f.look_at(
+            origin=o,
+            target=t,
+            up=[0, 1, 0]
+        ),
+        "film": {
+            "type": "hdrfilm",
+            "width": 512,
+            "height": 256,
+        }
+    }
+
+    return load_dict(camera_dict)
 
 
-origins    = [[1.0, 0.0, 1.5], [1.0, 4.0, 1.5]]
+origins = [[1.0, 0.0, 1.5], [1.0, 4.0, 1.5]]
 directions = [[0.0, 0.0, 1.0], [1.0, 0.0, 0.0]]
 
 

--- a/src/sensors/tests/test_radiancemeter.py
+++ b/src/sensors/tests/test_radiancemeter.py
@@ -1,53 +1,42 @@
-import enoki as ek
-import mitsuba
 import pytest
 
-
-def xml_sensor(params="", pixels="1"):
-    xml = f"""
-        <sensor version="2.0.0" type="radiancemeter">
-            <film type="hdrfilm">
-                <integer name="width" value="{pixels}"/>
-                <integer name="height" value="{pixels}"/>
-                <rfilter type="box"/>
-            </film>
-            {params}
-        </sensor>
-    """
-    return xml
+import enoki as ek
+import mitsuba
 
 
-def xml_lookat(origin, target, up="0,0,1"):
-    xml = f"""
-        <transform name="to_world">
-            <lookat origin="{origin}" target="{target}" up="{up}"/>
-        </transform>
-    """
-    return xml
+def make_sensor(origin=None, direction=None, to_world=None, pixels=1):
+    from mitsuba.core.xml import load_dict
 
+    d = {
+        "type": "radiancemeter",
+        "film": {
+            "type": "hdrfilm",
+            "width": pixels,
+            "height": pixels,
+            "rfilter": {"type": "box"}
+        }
+    }
 
-def xml_origin(value):
-    return f"""<point name="origin" value="{value}"/>"""
+    if origin is not None:
+        d["origin"] = origin
+    if direction is not None:
+        d["direction"] = direction
+    if to_world is not None:
+        d["to_world"] = to_world
 
-
-def xml_direction(value):
-    return f"""<vector name="direction" value="{value}"/>"""
-
-
-def example_sensor(params="", pixels="1"):
-    from mitsuba.core.xml import load_string
-    xml = xml_sensor(params, pixels)
-    return load_string(xml)
+    return load_dict(d)
 
 
 def test_construct(variant_scalar_rgb):
-    from mitsuba.core.xml import load_string
+    from mitsuba.core.xml import load_dict
+    from mitsuba.core import ScalarTransform4f
 
     # Test construct from to_world
-    only_to_world = xml_sensor(
-        params=xml_lookat(origin="0,0,0", target="0,1,0")
-    )
-    sensor = load_string(only_to_world)
+    sensor = make_sensor(to_world=ScalarTransform4f.look_at(
+        origin=[0, 0, 0],
+        target=[0, 1, 0],
+        up=[0, 0, 1]
+    ))
     assert not sensor.bbox().valid()  # Degenerate bounding box
     assert ek.allclose(
         sensor.world_transform().eval(0.).matrix,
@@ -58,10 +47,7 @@ def test_construct(variant_scalar_rgb):
     )
 
     # Test construct from origin and direction
-    origin_direction = xml_sensor(
-        params=xml_origin("0,0,0") + xml_direction("0,1,0")
-    )
-    sensor = load_string(origin_direction)
+    sensor = make_sensor(origin=[0, 0, 0], direction=[0, 1, 0])
     assert not sensor.bbox().valid()  # Degenerate bounding box
     assert ek.allclose(
         sensor.world_transform().eval(0.).matrix,
@@ -72,11 +58,15 @@ def test_construct(variant_scalar_rgb):
     )
 
     # Test to_world overriding direction + origin
-    to_world_origin_direction = xml_sensor(
-        params=xml_lookat(origin="0,0,0", target="0,1,0") +
-        xml_origin("1,0,0") + xml_direction("4,1,0")
+    sensor = make_sensor(
+        to_world=ScalarTransform4f.look_at(
+            origin=[0, 0, 0],
+            target=[0, 1, 0],
+            up=[0, 0, 1]
+        ),
+        origin=[1, 0, 0],
+        direction=[4, 1, 0]
     )
-    sensor = load_string(to_world_origin_direction)
     assert not sensor.bbox().valid()  # Degenerate bounding box
     assert ek.allclose(
         sensor.world_transform().eval(0.).matrix,
@@ -87,20 +77,15 @@ def test_construct(variant_scalar_rgb):
     )
 
     # Test raise on missing direction or origin
-    only_direction = xml_sensor(params=xml_direction("0,1,0"))
     with pytest.raises(RuntimeError):
-        sensor = load_string(only_direction)
+        sensor = make_sensor(direction=[0, 1, 0])
 
-    only_origin = xml_sensor(params=xml_origin("0,1,0"))
     with pytest.raises(RuntimeError):
-        sensor = load_string(only_origin)
+        sensor = make_sensor(origin=[0, 1, 0])
 
     # Test raise on wrong film size
     with pytest.raises(RuntimeError):
-        sensor = example_sensor(
-            params=xml_lookat(origin="0,0,-2", target="0,0,0"),
-            pixels=2
-        )
+        sensor = make_sensor(pixels=2)
 
 
 @pytest.mark.parametrize("direction", [[0.0, 0.0, 1.0], [-1.0, -1.0, 0.0], [2.0, 0.0, 0.0]])
@@ -108,11 +93,8 @@ def test_construct(variant_scalar_rgb):
 def test_sample_ray(variant_scalar_rgb, direction, origin):
     sample1 = [0.32, 0.87]
     sample2 = [0.16, 0.44]
-    direction_str = ",".join([str(x) for x in direction])
-    origin_str = ",".join([str(x) for x in origin])
-    sensor = example_sensor(
-        params=xml_direction(direction_str) + xml_origin(origin_str)
-    )
+
+    sensor = make_sensor(direction=direction, origin=origin)
 
     # Test regular ray sampling
     ray = sensor.sample_ray(1., 1., sample1, sample2, True)
@@ -129,36 +111,42 @@ def test_sample_ray(variant_scalar_rgb, direction, origin):
 @pytest.mark.parametrize("radiance", [10**x for x in range(-3, 4)])
 def test_render(variant_scalar_rgb, radiance):
     # Test render results with a simple scene
-    from mitsuba.core.xml import load_string
+    from mitsuba.core.xml import load_dict
     import numpy as np
 
-    scene_xml = """
-    <scene version="2.0.0">
-        <default name="radiance" value="1.0"/>
-        <default name="spp" value="1"/>
+    spp = 1
 
-        <integrator type="path"/>
+    scene_dict = {
+        "type": "scene",
+        "integrator": {
+            "type": "path"
+        },
+        "sensor": {
+            "type": "radiancemeter",
+            "film": {
+                "type": "hdrfilm",
+                "width": 1,
+                "height": 1,
+                "pixel_format": "rgb",
+                "rfilter": {
+                    "type": "box"
+                }
+            },
+            "sampler": {
+                "type": "independent",
+                "sample_count": spp
+            }
+        },
+        "emitter": {
+            "type": "constant",
+            "radiance": {
+                "type": "uniform",
+                "value": radiance
+            }
+        }
+    }
 
-        <sensor type="radiancemeter">
-            <film type="hdrfilm">
-                <integer name="width" value="1"/>
-                <integer name="height" value="1"/>
-                <string name="pixel_format" value="rgb"/>
-                <rfilter type="box"/>
-            </film>
-
-            <sampler type="independent">
-                <integer name="sample_count" value="$spp"/>
-            </sampler>
-        </sensor>
-
-        <emitter type="constant">
-            <spectrum name="radiance" value="$radiance"/>
-        </emitter>
-    </scene>
-    """
-
-    scene = load_string(scene_xml, spp=1, radiance=radiance)
+    scene = load_dict(scene_dict)
     sensor = scene.sensors()[0]
     scene.integrator().render(scene, sensor)
     img = sensor.film().bitmap()

--- a/src/sensors/tests/test_thinlens.py
+++ b/src/sensors/tests/test_thinlens.py
@@ -3,30 +3,34 @@ import pytest
 import enoki as ek
 
 
-def create_camera(o, d, fov=34, fov_axis='x', s_open=1.5, s_close=5, aperture=0.1, focus_dist=15):
-    from mitsuba.core.xml import load_string
-    return load_string("""<sensor version='2.0.0' type='thinlens'>
-                              <float name='near_clip' value='1'/>
-                              <float name='far_clip' value='35'/>
-                              <float name='focus_distance' value='{focus_dist}'/>
-                              <float name='aperture_radius' value='{aperture}'/>
-                              <float name='fov' value='{fov}'/>
-                              <string name='fov_axis' value='{fov_axis}'/>
-                              <float name='shutter_open' value='{so}'/>
-                              <float name='shutter_close' value='{sc}'/>
-                              <transform name="to_world">
-                                  <lookat origin="{ox}, {oy}, {oz}"
-                                          target="{tx}, {ty}, {tz}"
-                                          up    =" 0.0,  1.0,  0.0"/>
-                              </transform>
-                              <film type="hdrfilm">
-                                  <integer name="width" value="512"/>
-                                  <integer name="height" value="256"/>
-                              </film>
-                          </sensor> """.format(ox=o[0], oy=o[1], oz=o[2],
-                                               tx=o[0] + d[0], ty=o[1] + d[1], tz=o[2] + d[2],
-                                               fov=fov, fov_axis=fov_axis, so=s_open, sc=s_close,
-                                               aperture=aperture, focus_dist=focus_dist))
+def create_camera(o, d, fov=34, fov_axis="x", s_open=1.5, s_close=5, aperture=0.1, focus_dist=15):
+    from mitsuba.core.xml import load_dict
+    from mitsuba.core import ScalarTransform4f, ScalarVector3f
+    t = [o[0] + d[0], o[1] + d[1], o[2] + d[2]]
+
+    camera_dict = {
+        "type": "thinlens",
+        "near_clip": 1.0,
+        "far_clip": 35.0,
+        "focus_distance": focus_dist,
+        "aperture_radius": aperture,
+        "fov": fov,
+        "fov_axis": fov_axis,
+        "shutter_open": s_open, 
+        "shutter_close": s_close,
+        "to_world": ScalarTransform4f.look_at(
+            origin=o,
+            target=t,
+            up=[0, 1, 0]
+        ),
+        "film": {
+            "type": "hdrfilm",
+            "width": 512,
+            "height": 256,
+        }
+    }
+
+    return load_dict(camera_dict)
 
 
 origins = [[1.0, 0.0, 1.5], [1.0, 4.0, 1.5]]


### PR DESCRIPTION
## Description

_This is not really a bugfix but I couldn't figure out which PR prefix was best..._

This PR ports the tests for all sensor plugins to `load_dict`. I made a few fixes and structural changes to the scene generation code in the `radiancemeter` and `irradiancemeter` tests.

Other than that, no changes (in particular to the C++ codebase).

## Testing

Tested with the following variants: `scalar_rgb`, `scalar_spectral`, `packet_rgb`, `packet_spectral`.

## Checklist:

- [x] My changes generate no new warnings
- [x] I have commented my code
- [x] My code follows the style guidelines of this project
- [x] ~~My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave a note in the description above~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~

NB: I applied autopep8 and isort to the `radiancemeter` and `irradiancemeter` test code.