### PR TITLE
minor fix for medium documentation

### DIFF
--- a/src/bsdfs/dielectric.cpp
+++ b/src/bsdfs/dielectric.cpp
@@ -80,7 +80,7 @@ An example of how one might describe a slightly absorbing piece of glass is show
         </bsdf>
 
         <medium type="homogeneous" name="interior">
-            <float name="density" value="4"/>
+            <float name="scale" value="4"/>
 	    <rgb name="sigma_t" value="1, 1, 0.5"/>
 	    <rgb name="albedo" value="0.0, 0.0, 0.0"/>
         </medium>


### PR DESCRIPTION
Sorry, I could not find the appropriate label.

## Description

This is a very minor fix for the medium documentation as a follow-up of commit 9de53a90cc484daa1ff2fc365ae87f8c272c7a75 which did the following

```
- Rename "density_scale" (heterogeneous media) and "density" (homogeneous
media) to "scale" for consistency
```

Fixes # N/A

## Testing

N/A

## Checklist:

~~- [ ] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project~~
- [X] My changes generate no new warnings
~~- [] My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave below~~
~~- [ ] I have commented my code~~
- [X] I have made corresponding changes to the documentation
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I cleaned the commit history and removed any "Merge" commits~~
- [X] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)