### PR TITLE
Emitter plugin fixes [🐛 fix]

### DIFF
--- a/src/emitters/directional.cpp
+++ b/src/emitters/directional.cpp
@@ -84,8 +84,9 @@ public:
         MTS_MASKED_FUNCTION(ProfilerPhase::EndpointSampleRay, active);
 
         // 1. Sample spectrum
-        auto [wavelengths, weight] =
-            sample_wavelength<Float, Spectrum>(wavelength_sample);
+        auto [wavelengths, spec_weight] = m_irradiance->sample_spectrum(
+            zero<SurfaceInteraction3f>(),
+            math::sample_shifted<Wavelength>(wavelength_sample), active);
 
         // 2. Sample spatial component
         const Transform4f &trafo = m_world_transform->eval(time, active);
@@ -100,7 +101,7 @@ public:
         return std::make_pair(
             Ray3f(m_bsphere.center + (perp_offset - d) * m_bsphere.radius, d,
                   time, wavelengths),
-            unpolarized<Spectrum>(weight) *
+            unpolarized<Spectrum>(spec_weight) *
                 (math::Pi<Float> * sqr(m_bsphere.radius)));
     }
 

--- a/src/emitters/tests/test_area.py
+++ b/src/emitters/tests/test_area.py
@@ -94,7 +94,7 @@ def test03_sample_ray(variant_packet_spectral, spectrum_key):
 
     # Sample wavelengths on the spectrum
     it = SurfaceInteraction3f.zero(3)
-    wav, spec = spectrum.sample(it, sample_shifted(wavelength_sample))
+    wav, spec = spectrum.sample_spectrum(it, sample_shifted(wavelength_sample))
 
     # Sample a position on the shape
     ps = shape.sample_position(time, pos_sample)

--- a/src/emitters/tests/test_constant.py
+++ b/src/emitters/tests/test_constant.py
@@ -62,7 +62,7 @@ def test02_sample_ray(variant_packet_spectral, spectrum_key):
 
     # Sample wavelengths on the spectrum
     it = SurfaceInteraction3f.zero(3)
-    wav, spec = spectrum.sample(it, sample_shifted(wavelength_sample))
+    wav, spec = spectrum.sample_spectrum(it, sample_shifted(wavelength_sample))
 
     assert ek.allclose(res, spec * 4 * ek.pi * ek.pi)
     assert ek.allclose(ray.time, time)

--- a/src/emitters/tests/test_point.py
+++ b/src/emitters/tests/test_point.py
@@ -50,7 +50,7 @@ def test01_point_sample_ray(variant_packet_spectral, spectrum_key):
 
     # Sample wavelengths on the spectrum
     it = SurfaceInteraction3f.zero(3)
-    wav, spec = spectrum.sample(it, sample_shifted(wavelength_sample))
+    wav, spec = spectrum.sample_spectrum(it, sample_shifted(wavelength_sample))
 
     assert ek.allclose(res, spec * 4 * ek.pi)
     assert ek.allclose(ray.time, time)

--- a/src/emitters/tests/test_spot.py
+++ b/src/emitters/tests/test_spot.py
@@ -127,7 +127,7 @@ def test_sample_ray(variant_packet_spectral, spectrum_key, wavelength_sample, po
 
     # Sample wavelengths on the spectrum
     it = SurfaceInteraction3f.zero()
-    wav, spec = spectrum.sample(it, sample_shifted(wavelength_sample))
+    wav, spec = spectrum.sample_spectrum(it, sample_shifted(wavelength_sample))
     it.wavelengths = wav
     spec = spectrum.eval(it)
     spec = ek.select(angle <= beam_width_rad, spec, spec *


### PR DESCRIPTION
## Description

This PR adds wavelength sampling based on irradiance spectrum to the `directional` plugin. In addition, I fixed wrong sampling method calls subsequent to the `Texture` API changes.

The `spot` plugin tests still fail but I couldn't figure out why.

## Testing

I added a check for wavelength sampling to the `directional` plugin tests.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `gpu_*` and `packet_*` variants
- [x] I have commented my code
- [x] ~~I have made corresponding changes to the documentation~~ [no docs update required]
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)

The code compiles for packet variants. I cannot test it with gpu variants.