### PR TITLE
Support for texture packing  [✨ new feature]

### DIFF
--- a/include/mitsuba/core/bitmap.h
+++ b/include/mitsuba/core/bitmap.h
@@ -239,9 +239,8 @@ public:
     /// Move constructor
     Bitmap(Bitmap &&bitmap);
 
-
+    // Returns number of bytes per pixel channel
     int get_bytes_per_component() const;
-
 
     /// Return the pixel format of this bitmap
     PixelFormat pixel_format() const { return m_pixel_format; }

--- a/include/mitsuba/core/bitmap.h
+++ b/include/mitsuba/core/bitmap.h
@@ -239,6 +239,10 @@ public:
     /// Move constructor
     Bitmap(Bitmap &&bitmap);
 
+
+    int getBytesPerComponent() const;
+
+
     /// Return the pixel format of this bitmap
     PixelFormat pixel_format() const { return m_pixel_format; }
 
@@ -379,6 +383,13 @@ public:
     /// Equivalent to \ref write(), but executes asynchronously on a different thread
     void write_async(const fs::path &path, FileFormat format = FileFormat::Auto,
                      int quality = -1) const;
+
+    /**
+     * \brief Extract several color channels of a multi-channel
+     * bitmap and return them as a bitmap with the given pixel format
+     */
+    ref<Bitmap> Bitmap::extractChannels(PixelFormat fmt, const std::vector<int> &channels) const;
+
 
     /**
      * \brief Up- or down-sample this image to a different resolution

--- a/include/mitsuba/core/bitmap.h
+++ b/include/mitsuba/core/bitmap.h
@@ -240,7 +240,7 @@ public:
     Bitmap(Bitmap &&bitmap);
 
 
-    int getBytesPerComponent() const;
+    int get_bytes_per_component() const;
 
 
     /// Return the pixel format of this bitmap

--- a/include/mitsuba/core/bitmap.h
+++ b/include/mitsuba/core/bitmap.h
@@ -388,7 +388,7 @@ public:
      * \brief Extract several color channels of a multi-channel
      * bitmap and return them as a bitmap with the given pixel format
      */
-    ref<Bitmap> Bitmap::extractChannels(PixelFormat fmt, const std::vector<int> &channels) const;
+    ref<Bitmap> Bitmap::extract_channels(PixelFormat fmt, const std::vector<int> &channels) const;
 
 
     /**

--- a/src/libcore/bitmap.cpp
+++ b/src/libcore/bitmap.cpp
@@ -364,7 +364,7 @@ ref<Bitmap> Bitmap::resample(const Vector2u &res, const ReconstructionFilter *rf
     return result;
 }
 
-int Bitmap::getBytesPerComponent() const {
+int Bitmap::get_bytes_per_component() const {
     switch (m_component_format) {
         case Struct::Type::UInt8:
         case Struct::Type::Int8:
@@ -400,7 +400,7 @@ int Bitmap::getBytesPerComponent() const {
     }
 }
 
-ref<Bitmap> Bitmap::extractChannels(const PixelFormat fmt, const std::vector<int> &channels) const {
+ref<Bitmap> Bitmap::extract_channels(const PixelFormat fmt, const std::vector<int> &channels) const {
     size_t channelCount = channel_count();
 
     for (size_t i = 0; i < channels.size(); ++i)
@@ -417,7 +417,7 @@ ref<Bitmap> Bitmap::extractChannels(const PixelFormat fmt, const std::vector<int
     //result->m_struct   = m_struct;
     result->m_metadata = m_metadata;
 
-    size_t componentSize = getBytesPerComponent();
+    size_t componentSize = get_bytes_per_component();
     size_t stride        = channelCount * componentSize;
     size_t pixelCount    = (size_t) m_size.x() * (size_t) m_size.y();
 

--- a/src/textures/bitmap.cpp
+++ b/src/textures/bitmap.cpp
@@ -234,7 +234,7 @@ public:
      * Parse the channel string into a vector of channels and a new pixel format based on the new number of channels
      * e.g.: r => [0] or rb => [0,2] or bg => [2,1] 
      */
-    static std::vector<int> findChannels(const std::string channelStr, Bitmap::PixelFormat& new_fmt) {
+    static std::vector<int> find_channels(const std::string channel_str, Bitmap::PixelFormat& new_fmt) {
 
         std::vector<int> channels;
         for (std::string::size_type i = 0; i < channelStr.size(); ++i) {

--- a/src/textures/bitmap.cpp
+++ b/src/textures/bitmap.cpp
@@ -126,24 +126,18 @@ public:
         m_bitmap = new Bitmap(file_path);
         Bitmap::PixelFormat pixel_format = m_bitmap->pixel_format();
 
-
         m_channel = props.string("channel", "");
         if (!m_channel.empty()) {
             /* Create a texture from a certain channel of an image */
-            
-
             Bitmap::PixelFormat new_fmt;
             std::vector<int> channels = find_channels(m_channel, new_fmt);
             m_bitmap = m_bitmap->extract_channels(new_fmt, channels);
-
 
             Log(Debug,
                 "BitmapTexture: extracted channel \"%s\" out of PixelFormat.%d to create "
                 "a new bitmap with pixel format PixelFormat.%d.",
                 m_channel, pixel_format, new_fmt);
         }
-
-
 
         /* Convert to linear RGB float bitmap, will be converted
            into spectral profile coefficients below (in place) */

--- a/src/textures/bitmap.cpp
+++ b/src/textures/bitmap.cpp
@@ -133,8 +133,8 @@ public:
             
 
             Bitmap::PixelFormat new_fmt;
-            std::vector<int> channels = findChannels(m_channel, new_fmt);
-            m_bitmap = m_bitmap->extractChannels(new_fmt, channels);
+            std::vector<int> channels = find_channels(m_channel, new_fmt);
+            m_bitmap = m_bitmap->extract_channels(new_fmt, channels);
 
 
             Log(Debug,
@@ -237,9 +237,9 @@ public:
     static std::vector<int> find_channels(const std::string channel_str, Bitmap::PixelFormat& new_fmt) {
 
         std::vector<int> channels;
-        for (std::string::size_type i = 0; i < channelStr.size(); ++i) {
+        for (std::string::size_type i = 0; i < channel_str.size(); ++i) {
             int channel = 0;
-            char c = std::tolower(channelStr[i]);
+            char c = std::tolower(channel_str[i]);
             if (c == 'r' || c == 'x')
                 channel = 0;
             else if (c == 'g' || c == 'y')
@@ -252,10 +252,10 @@ public:
                 Log(Warn,
                     "Unsupported channel %c in \"%s\" for converting to "
                     "monochromatic bitmap.",
-                    c, channelStr);
+                    c, channel_str);
                 Throw("Unsupported channel %c in \"%s\" for converting to "
                       "monochromatic bitmap.",
-                      c, channelStr);
+                      c, channel_str);
             }
             channels.emplace_back(channel);
         }


### PR DESCRIPTION
This PR adds support for texture packing. This allows the user to select/filter one or multiple channels which are converted internally to a new monochromatic or rgb bitmap. The channels to select be chosen using the new 'channel' property of bitmap textures (as inspired by Mitsuba 0.6).

## Description
This required changes in three files:
- *\src\libcore\bitmap.cpp*: Added a function **extractChannels** to extract one or more channels out of an existing bitmap (ported code from Mitsuba 0.6). This requires a helper function **getBytesPerComponent** to idenitfy the number of bytes per pixel.
- *\include\mitsuba\core\bitmap.h Added function declarations for **extractChannels** and **getBytesPerComponent**
- *\src\textures\bitmap.cpp*: Code for parsing the channel property, which is a string, into a vector of channels to extract. Here the bitmap is altered and interchanged with the newly generated bitmap. When no *channel* property is provided, the bitmap stays unchanged.

## Testing

The PR is tested for rgb variant. Not tested yet for `gpu_*` and `packet_*` variants.

## Checklist:

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [ ] Testing for `gpu_*` and `packet_*` variants. 
- [x] I have commented my code
- [ ] Documentation
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)