### PR TITLE
Simple Dockerfiles for both CPU and GPU

### DIFF
--- a/resources/docker/README.md
+++ b/resources/docker/README.md
@@ -1,0 +1,71 @@
+# Docker files for Mitsuba 2
+
+Here are Docker files for running Mitsuba 2 either CPU only, or also with GPU support.
+
+**Attention!** For GPU and CUDA/OptiX to work, you need to have new Nvidia drivers with builtin OptiX libraries, and also updated Docker and Nvidia Docker that provide proper mounting of OptiX libraries. You do **not** need to install OptiX SDK, it is **not** necessary for Mitsuba 2! Only the updated Nvidia drivers and Docker are needed.
+
+## Building the images
+
+Building the CPU only version:
+
+```
+docker build -t mitsuba2:cpu -f linux-cpu.Dockerfile .
+```
+
+Building the CPU/GPU version:
+
+```
+docker build -t mitsuba2:gpu -f linux-gpu.Dockerfile .
+```
+
+The images will be tagged as `mitsuba2:cpu` or `mitsuba2:gpu`.
+
+## Starting the containers
+
+Running the CPU image:
+
+```
+cd /path/to/mitsuba2
+docker run -it -p 45678:8888 -v $(pwd):/mitsuba2 -u $(id -u):$(id -g) mitsuba2:cpu bash
+```
+
+This will mount the Mitsuba 2 root directory to `/mitsuba2` inside the container and map port `8888` (used for Jupyter) from the container to port `45678` in the host machine.
+
+Running the GPU image:
+
+```
+cd /path/to/mitsuba2
+docker run --runtime=nvidia --gpus all -it -p 45678:8888 -v $(pwd):/mitsuba2 -u $(id -u):$(id -g) mitsuba2:gpu bash
+```
+
+This will do the same as above, and also mount all available GPUs to the container.
+
+## Compiling Mitsuba 2
+
+Works the same as described in Mitsuba 2 documentation:
+
+```
+cd /mitsuba2
+mkdir build
+cd build
+cmake -GNinja ..
+ninja
+```
+
+## Running Mitsuba 2
+
+```
+cd /mitsuba2
+source setpath.sh
+mitsuba2 --help
+```
+
+## Running Jupyter
+
+```
+cd /mitsuba2
+source setpath.sh
+jupyter notebook --port 8888 --ip 0.0.0.0
+```
+
+And then you can connect to the Jupyter notebook via `localhost:45678` in your web browser.

--- a/resources/docker/README.md
+++ b/resources/docker/README.md
@@ -2,19 +2,21 @@
 
 Here are Docker files for running Mitsuba 2 either CPU only, or also with GPU support.
 
-**Attention!** For GPU and CUDA/OptiX to work, you need to have new Nvidia drivers with builtin OptiX libraries, and also updated Docker and Nvidia Docker that provide proper mounting of OptiX libraries. You do **not** need to install OptiX SDK, it is **not** necessary for Mitsuba 2! Only the updated Nvidia drivers and Docker are needed.
+**Attention!** For GPU and CUDA/OptiX to work, you need to have new Nvidia drivers with builtin OptiX libraries, and also updated Docker and Nvidia Docker that provide proper mounting of OptiX libraries. You do **not** need to install OptiX SDK, it is **not** necessary for new versions of Mitsuba 2! Only the updated Nvidia drivers and Docker are needed.
 
 ## Building the images
 
 Building the CPU only version:
 
 ```
+cd /path/to/mitsuba2/resources/docker
 docker build -t mitsuba2:cpu -f linux-cpu.Dockerfile .
 ```
 
 Building the CPU/GPU version:
 
 ```
+cd /path/to/mitsuba2/resources/docker
 docker build -t mitsuba2:gpu -f linux-gpu.Dockerfile .
 ```
 
@@ -38,11 +40,13 @@ cd /path/to/mitsuba2
 docker run --runtime=nvidia --gpus all -it -p 45678:8888 -v $(pwd):/mitsuba2 -u $(id -u):$(id -g) mitsuba2:gpu bash
 ```
 
-This will do the same as above, and also mount all available GPUs to the container.
+This will do the same as above, and also mount all available GPUs to the container. You can try running `nvidia-smi` inside the container to verify the GPUs have been mounted correctly.
 
 ## Compiling Mitsuba 2
 
-Works the same as described in Mitsuba 2 documentation:
+Works the same as described in Mitsuba 2 documentation.
+
+Note: Do not forget to modify `mitsuba.conf` if you want to add GPU variants.
 
 ```
 cd /mitsuba2
@@ -57,7 +61,7 @@ ninja
 ```
 cd /mitsuba2
 source setpath.sh
-mitsuba2 --help
+mitsuba --help
 ```
 
 ## Running Jupyter

--- a/resources/docker/linux-cpu.Dockerfile
+++ b/resources/docker/linux-cpu.Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:18.04
+
+# Install build tools, including Clang and libc++ (Clang's C++ library)
+RUN apt-get update && apt-get install -y \
+    clang-9 \
+    cmake \
+    libc++-9-dev \
+    libc++abi-9-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libxcursor-dev \
+    libxinerama-dev \
+    libxrandr-dev \
+    libz-dev \
+    ninja-build \ 
+    python3-dev \
+    python3-distutils \
+    python3-setuptools \
+    python3-pip
+
+# Install basic Python tools
+RUN pip3 install jupyterlab numpy matplotlib ipywidgets
+
+# create /.local so that Python and Jupyter are happy
+RUN mkdir /.local && chmod a+rwx /.local
+
+# Set C/C++ compilers to Clang
+ENV CC=clang-9
+ENV CXX=clang++-9
+
+WORKDIR /mitsuba2
+CMD ["/bin/bash"]

--- a/resources/docker/linux-gpu.Dockerfile
+++ b/resources/docker/linux-gpu.Dockerfile
@@ -1,0 +1,36 @@
+# Start from CUDA 10.2 development image
+FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility,graphics
+
+# Install build tools, including Clang and libc++ (Clang's C++ library)
+RUN apt-get update && apt-get install -y \
+    clang-9 \
+    cmake \
+    libc++-9-dev \
+    libc++abi-9-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libxcursor-dev \
+    libxinerama-dev \
+    libxrandr-dev \
+    libz-dev \
+    ninja-build \ 
+    python3-dev \
+    python3-distutils \
+    python3-setuptools \
+    python3-pip
+
+# Install basic Python tools
+RUN pip3 install jupyterlab numpy matplotlib ipywidgets
+
+# create /.local so that Python and Jupyter are happy
+RUN mkdir /.local && chmod a+rwx /.local
+
+# Set C/C++ compilers to Clang
+ENV CC=clang-9
+ENV CXX=clang++-9
+
+WORKDIR /mitsuba2
+CMD ["/bin/bash"]


### PR DESCRIPTION
## Description

The official Mitsuba 2 repository does not contain any Dockerfiles to be easily able to run Mitsuba 2 in a container. Because not everyone wants to run software on bare machines, and also to simplify reproducibility, @diiigle and I made two very simple Dockerfiles based on Ubuntu that support both CPU and GPU variants.

The pull request contains two Dockerfiles and a separate README file.

Please let me know if this pull request is acceptable and/or if some changes to the original documentation should also be made. :)

## Testing

No automated testing available

## Checklist:

*Please make sure to complete this checklist before requesting a review.*

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)