### PR TITLE
Orthographic sensor plugin

### DIFF
--- a/include/mitsuba/render/sensor.h
+++ b/include/mitsuba/render/sensor.h
@@ -230,6 +230,43 @@ perspective_projection(const Vector<int, 2> &film_size,
            Transform4f::perspective(fov_x, near_clip, far_clip);
 }
 
+template <typename Float> Transform<Point<Float, 4>>
+orthographic_projection(const Vector<int, 2> &film_size,
+                        const Vector<int, 2> &crop_size,
+                        const Vector<int, 2> &crop_offset,
+                        Float near_clip, Float far_clip) {
+
+    using Vector2f = Vector<Float, 2>;
+    using Vector3f = Vector<Float, 3>;
+    using Transform4f = Transform<Point<Float, 4>>;
+
+    Vector2f film_size_f = Vector2f(film_size),
+             rel_size    = Vector2f(crop_size) / film_size_f,
+             rel_offset  = Vector2f(crop_offset) / film_size_f;
+
+    Float aspect = film_size_f.x() / film_size_f.y();
+
+    /**
+     * These do the following (in reverse order):
+     *
+     * 1. Create transform from camera space to [-1,1]x[-1,1]x[0,1] clip
+     *    coordinates (not taking account of the aspect ratio yet)
+     *
+     * 2+3. Translate and scale to shift the clip coordinates into the
+     *    range from zero to one, and take the aspect ratio into account.
+     *
+     * 4+5. Translate and scale the coordinates once more to account
+     *     for a cropping window (if there is any)
+     */
+    return Transform4f::scale(
+               Vector3f(1.f / rel_size.x(), 1.f / rel_size.y(), 1.f)) *
+           Transform4f::translate(
+               Vector3f(-rel_offset.x(), -rel_offset.y(), 0.f)) *
+           Transform4f::scale(Vector3f(-0.5f, -0.5f * aspect, 1.f)) *
+           Transform4f::translate(Vector3f(-1.f, -1.f / aspect, 0.f)) *
+           Transform4f::orthographic(near_clip, far_clip);
+}
+
 //! @}
 // ========================================================================
 

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(MTS_PLUGIN_PREFIX "sensors")
 
 add_plugin(perspective     perspective.cpp)
+add_plugin(orthographic    orthographic.cpp)
 add_plugin(radiancemeter   radiancemeter.cpp)
 add_plugin(thinlens        thinlens.cpp)
 add_plugin(irradiancemeter irradiancemeter.cpp)

--- a/src/sensors/orthographic.cpp
+++ b/src/sensors/orthographic.cpp
@@ -1,0 +1,231 @@
+#include <mitsuba/render/sensor.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/transform.h>
+#include <mitsuba/core/bbox.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _sensor-ortographic:
+
+Orthographic camera (:monosp:`orthographic`)
+--------------------------------------------------
+
+.. pluginparameters::
+
+ * - to_world
+   - |transform|
+   - Specifies an optional camera-to-world transformation.
+     (Default: none (i.e. camera space = world space))
+ * - near_clip, far_clip
+   - |float|
+   - Distance to the near/far clip planes. (Default: :monosp:`near_clip=1e-2` (i.e. :monosp:`0.01`)
+     and :monosp:`far_clip=1e4` (i.e. :monosp:`10000`))
+
+.. subfigstart::
+.. subfigure:: ../../resources/data/docs/images/render/sensor_orthographic.jpg
+   :caption: The material test ball viewed through an orthographic camera.
+   Note the complete lack of perspective.)
+.. subfigure:: ../../resources/data/docs/images/render/sensor_orthographic_2.jpg
+   :caption: A rendering of the Cornell box
+.. subfigend::
+   :label: fig-orthographic
+
+This plugin implements a simple orthographic camera, i.e. a sensor
+based on an orthographic projection without any form of perspective.
+It can be thought of as a planar sensor that measures the radiance
+along its normal direction. By default, this is the region $[-1, 1]^2$ inside
+the XY-plane facing along the positive Z direction. Transformed versions
+can be instantiated e.g. as follows:
+
+The exact camera position and orientation is most easily expressed using the
+:monosp:`lookat` tag, i.e.:
+
+.. code-block:: xml
+
+    <sensor type="orthographic">
+        <transform name="to_world">
+            <!-- Resize the sensor plane to 20x20 world space units -->
+            <scale x="10" y="10"/>
+            
+            <!-- Move and rotate the camera so that looks from (1, 1, 1) to (1, 2, 1)
+                and the direction (0, 0, 1) points "up" in the output image -->
+            <lookat origin="1, 1, 1" target="1, 2, 1" up="0, 0, 1"/>
+        </transform>
+    </sensor>
+
+ */
+
+template <typename Float, typename Spectrum>
+class OrthographicCamera final : public ProjectiveCamera<Float, Spectrum> {
+public:
+    MTS_IMPORT_BASE(ProjectiveCamera, m_world_transform, m_needs_sample_3, m_film, m_sampler,
+                    m_resolution, m_shutter_open, m_shutter_open_time, m_aspect, m_near_clip,
+                    m_far_clip)
+    MTS_IMPORT_TYPES()
+
+    // =============================================================
+    //! @{ \name Constructors
+    // =============================================================
+
+    OrthographicCamera(const Properties &props) : Base(props) {
+        update_camera_transforms();
+    }
+
+    // TODO duplicate code with ThinLens
+    void update_camera_transforms() {
+        ScalarVector2f film_size = ScalarVector2f(m_film->size()),
+                       crop_size = ScalarVector2f(m_film->crop_size()),
+                       rel_size  = crop_size / film_size;
+
+        ScalarPoint2f crop_offset = ScalarPoint2f(m_film->crop_offset()),
+                      rel_offset  = crop_offset / film_size;
+
+        /**
+         * These do the following (in reverse order):
+         *
+         * 1. Create transform from camera space to [-1,1]x[-1,1]x[0,1] clip
+         *    coordinates (not taking account of the aspect ratio yet)
+         *
+         * 2+3. Translate and scale to shift the clip coordinates into the
+         *    range from zero to one, and take the aspect ratio into account.
+         *
+         * 4+5. Translate and scale the coordinates once more to account
+         *     for a cropping window (if there is any)
+         */
+        m_camera_to_sample =
+            ScalarTransform4f::scale(ScalarVector3f(1.f / rel_size.x(), 1.f / rel_size.y(), 1.f)) *
+            ScalarTransform4f::translate(ScalarVector3f(-rel_offset.x(), -rel_offset.y(), 0.f)) *
+            ScalarTransform4f::scale(ScalarVector3f(-0.5f, -0.5f * m_aspect, 1.f)) *
+            ScalarTransform4f::translate(ScalarVector3f(-1.f, -1.f / m_aspect, 0.f)) *
+            ScalarTransform4f::orthographic(m_near_clip, m_far_clip);
+
+        m_sample_to_camera = m_camera_to_sample.inverse();
+
+        // Position differentials on the near plane
+        m_dx = m_sample_to_camera * ScalarPoint3f(1.f / m_resolution.x(), 0.f, 0.f) -
+               m_sample_to_camera * ScalarPoint3f(0.f);
+        m_dy = m_sample_to_camera * ScalarPoint3f(0.f, 1.f / m_resolution.y(), 0.f)
+             - m_sample_to_camera * ScalarPoint3f(0.f);
+
+        m_normalization = 1.f / m_image_rect.volume();
+    }
+
+    //! @}
+    // =============================================================
+
+    // =============================================================
+    //! @{ \name Sampling methods (Sensor interface)
+    // =============================================================
+
+    std::pair<Ray3f, Spectrum> sample_ray(Float time, Float wavelength_sample,
+                                          const Point2f &position_sample,
+                                          const Point2f & /*aperture_sample*/,
+                                          Mask active) const override {
+        MTS_MASKED_FUNCTION(ProfilerPhase::EndpointSampleRay, active);
+
+        auto [wavelengths, wav_weight] = sample_wavelength<Float, Spectrum>(wavelength_sample);
+        Ray3f ray;
+        ray.time = time;
+        ray.wavelengths = wavelengths;
+
+        // Compute the sample position on the near plane (local camera space).
+        Point3f near_p = m_sample_to_camera *
+                         Point3f(position_sample.x(), position_sample.y(), 0.f);
+
+        ray.mint = m_near_clip;
+        ray.maxt = m_far_clip;
+
+        auto trafo = m_world_transform->eval(ray.time, active);
+        ray.o = trafo.transform_affine(Point3f(near_p.x(), near_p.y(), 0.f));
+        ray.d = normalize(trafo * Vector3f(0, 0, 1));
+        ray.update();
+
+        return std::make_pair(ray, wav_weight);
+    }
+
+    std::pair<RayDifferential3f, Spectrum>
+    sample_ray_differential(Float time, Float wavelength_sample, const Point2f &position_sample,
+                            const Point2f & /*aperture_sample*/, Mask active) const override {
+        MTS_MASKED_FUNCTION(ProfilerPhase::EndpointSampleRay, active);
+
+        auto [wavelengths, wav_weight] = sample_wavelength<Float, Spectrum>(wavelength_sample);
+        RayDifferential3f ray;
+        ray.time = time;
+        ray.wavelengths = wavelengths;
+
+        // Compute the sample position on the near plane (local camera space).
+        Point3f near_p = m_sample_to_camera *
+                         Point3f(position_sample.x(), position_sample.y(), 0.f);
+
+        ray.mint = m_near_clip;
+        ray.maxt = m_far_clip;
+
+        auto trafo = m_world_transform->eval(ray.time, active);
+        ray.o = trafo.transform_affine(near_p);
+        ray.d = normalize(trafo * Vector3f(0, 0, 1));
+        ray.update();
+
+        ray.o_x = ray.o_y = ray.o;
+
+        ray.d_x = trafo * normalize(Vector3f(near_p) + m_dx);
+        ray.d_y = trafo * normalize(Vector3f(near_p) + m_dy);
+        ray.has_differentials = true;
+
+        return std::make_pair(ray, wav_weight);
+    }
+
+    ScalarBoundingBox3f bbox() const override {
+        return m_world_transform->translation_bounds();
+    }
+
+    void set_crop_window(const ScalarVector2i &crop_size,
+                         const ScalarPoint2i &crop_offset) override {
+        Base::set_crop_window(crop_size, crop_offset);
+        update_camera_transforms();
+    }
+
+    //! @}
+    // =============================================================
+
+    void traverse(TraversalCallback *callback) override {
+        Base::traverse(callback);
+        // TODO
+    }
+
+    void parameters_changed(const std::vector<std::string> &keys) override {
+        Base::parameters_changed(keys);
+        // TODO
+    }
+
+    std::string to_string() const override {
+        using string::indent;
+
+        std::ostringstream oss;
+        oss << "OrthographicCamera[" << std::endl
+            << "  near_clip = " << m_near_clip << "," << std::endl
+            << "  far_clip = " << m_far_clip << "," << std::endl
+            << "  film = " << indent(m_film) << "," << std::endl
+            << "  sampler = " << indent(m_sampler) << "," << std::endl
+            << "  resolution = " << m_resolution << "," << std::endl
+            << "  shutter_open = " << m_shutter_open << "," << std::endl
+            << "  shutter_open_time = " << m_shutter_open_time << "," << std::endl
+            << "  aspect = " << m_aspect << "," << std::endl
+            << "  world_transform = " << indent(m_world_transform)  << std::endl
+            << "]";
+        return oss.str();
+    }
+
+    MTS_DECLARE_CLASS()
+private:
+    ScalarTransform4f m_camera_to_sample;
+    ScalarTransform4f m_sample_to_camera;
+    ScalarBoundingBox2f m_image_rect;
+    ScalarFloat m_normalization;
+    ScalarVector3f m_dx, m_dy;
+};
+
+MTS_IMPLEMENT_CLASS_VARIANT(OrthographicCamera, ProjectiveCamera)
+MTS_EXPORT_PLUGIN(OrthographicCamera, "Orthographic Camera");
+NAMESPACE_END(mitsuba)

--- a/src/sensors/tests/test_orthographic.py
+++ b/src/sensors/tests/test_orthographic.py
@@ -1,0 +1,121 @@
+import mitsuba
+import pytest
+import enoki as ek
+
+
+def create_camera(o, d, s_open=1.5, s_close=5):
+    from mitsuba.core.xml import load_string
+    return load_string("""<sensor version='2.0.0' type='orthographic'>
+                              <float name='near_clip' value='1'/>
+                              <float name='far_clip' value='35'/>
+                              <float name='shutter_open' value='{so}'/>
+                              <float name='shutter_close' value='{sc}'/>
+                              <transform name="to_world">
+                                  <lookat origin="{ox}, {oy}, {oz}"
+                                          target="{tx}, {ty}, {tz}"
+                                          up    =" 0.0,  1.0,  0.0"/>
+                              </transform>
+                              <film type="hdrfilm">
+                                  <integer name="width" value="512"/>
+                                  <integer name="height" value="256"/>
+                              </film>
+                          </sensor> """.format(ox=o[0], oy=o[1], oz=o[2],
+                                               tx=o[0]+d[0], ty=o[1]+d[1], tz=o[2]+d[2],
+                                               so=s_open, sc=s_close))
+
+
+origins    = [[1.0, 0.0, 1.5], [1.0, 4.0, 1.5]]
+directions = [[0.0, 0.0, 1.0], [1.0, 0.0, 0.0]]
+
+
+@pytest.mark.parametrize("origin", origins)
+@pytest.mark.parametrize("direction", directions)
+@pytest.mark.parametrize("s_open", [0.0, 1.5])
+@pytest.mark.parametrize("s_time", [0.0, 3.0])
+def test01_create(variant_scalar_rgb, origin, direction, s_open, s_time):
+    from mitsuba.core import BoundingBox3f, Vector3f, Transform4f
+
+    camera = create_camera(origin, direction, s_open=s_open, s_close=s_open + s_time)
+
+    assert ek.allclose(camera.near_clip(), 1)
+    assert ek.allclose(camera.far_clip(), 35)
+    assert ek.allclose(camera.shutter_open(), s_open)
+    assert ek.allclose(camera.shutter_open_time(), s_time)
+    assert not camera.needs_aperture_sample()
+    assert camera.bbox() == BoundingBox3f(origin, origin)
+    assert ek.allclose(camera.world_transform().eval(0).matrix,
+                       Transform4f.look_at(origin, Vector3f(origin) + direction, [0, 1, 0]).matrix)
+
+
+@pytest.mark.parametrize("origin", origins)
+@pytest.mark.parametrize("direction", directions)
+def test02_sample_ray(variant_packet_spectral, origin, direction):
+    # Check the correctness of the sample_ray() method
+    from mitsuba.core import sample_shifted, sample_rgb_spectrum
+
+    camera = create_camera(origin, direction)
+
+    time = 0.5
+    wav_sample = [0.5, 0.33, 0.1]
+    pos_sample = [[0.2, 0.1, 0.2], [0.6, 0.9, 0.2]]
+    aperture_sample = 0 # Not being used
+
+    ray, spec_weight = camera.sample_ray(time, wav_sample, pos_sample, aperture_sample)
+
+    # Importance sample wavelength and weight
+    wav, spec = sample_rgb_spectrum(sample_shifted(wav_sample))
+
+    assert ek.allclose(ray.wavelengths, wav)
+    assert ek.allclose(spec_weight, spec)
+    assert ek.allclose(ray.time, time)
+    assert ek.allclose(ray.o, origin)
+
+    # Check that a [0.5, 0.5] position_sample generates a ray
+    # that points in the camera direction
+    ray, _ = camera.sample_ray(0, 0, [0.5, 0.5], 0)
+    assert ek.allclose(ray.d, direction, atol=1e-7)
+
+
+
+@pytest.mark.parametrize("origin", origins)
+@pytest.mark.parametrize("direction", directions)
+def test03_sample_ray_differential(variant_packet_spectral, origin, direction):
+    # Check the correctness of the sample_ray_differential() method
+    from mitsuba.core import sample_shifted, sample_rgb_spectrum
+
+    camera = create_camera(origin, direction)
+
+    time = 0.5
+    wav_sample = [0.5, 0.33, 0.1]
+    pos_sample = [[0.2, 0.1, 0.2], [0.6, 0.9, 0.2]]
+
+    ray, spec_weight = camera.sample_ray_differential(time, wav_sample, pos_sample, 0)
+
+    # Importance sample wavelength and weight
+    wav, spec = sample_rgb_spectrum(sample_shifted(wav_sample))
+
+    assert ek.allclose(ray.wavelengths, wav)
+    assert ek.allclose(spec_weight, spec)
+    assert ek.allclose(ray.time, time)
+    assert ek.allclose(ray.o, origin)
+
+    # Check that the derivatives are orthogonal
+    assert ek.allclose(ek.dot(ray.d_x - ray.d, ray.d_y - ray.d), 0, atol=1e-7)
+
+    # Check that a [0.5, 0.5] position_sample generates a ray
+    # that points in the camera direction
+    ray_center, _ = camera.sample_ray_differential(0, 0, [0.5, 0.5], 0)
+    assert ek.allclose(ray_center.d, direction, atol=1e-7)
+
+    # Check correctness of the ray derivatives
+
+    # Deltas in screen space
+    dx = 1.0 / camera.film().crop_size().x
+    dy = 1.0 / camera.film().crop_size().y
+
+    # Sample the rays by offsetting the position_sample with the deltas
+    ray_dx, _ = camera.sample_ray_differential(0, 0, [0.5 + dx, 0.5], 0)
+    ray_dy, _ = camera.sample_ray_differential(0, 0, [0.5, 0.5 + dy], 0)
+
+    assert ek.allclose(ray_dx.d, ray_center.d_x)
+    assert ek.allclose(ray_dy.d, ray_center.d_y)


### PR DESCRIPTION
## Description

This PR adds an orthographic camera to the collection of sensors. This is a simple modification of the `PerspectiveCamera` where the projection was changed to orthographic (and rays are mapped accordingly). The documentation header follows [Mitsuba 0.6](https://github.com/mitsuba-renderer/mitsuba/blob/master/src/sensors/orthographic.cpp).

## Testing

A simple test script is provided, but may need more as it is just a distilled version of `test_perspective.py` without the FOV bits. Moreover, documentation build needs to be checked as I couldn't get Sphinx to work due to some version error with `sphinx-build` on my end.

### Example renders for docs
Below are example test scenes for the docs, adapted from `resources/data/docs/scenes/sensor_perspective.xml` and `resources/data/docs/scenes/integrator_depth_3.xml` respectively. Both are rendered at 1024 SPP and a camera scaling is provided for reproducibility.

Material test ball      |  Cornell box
:-------------------------:|:-------------------------:
![](https://i.imgur.com/XFvif8d.jpg)  |  ![](https://i.imgur.com/cz52fQd.jpg)
`<scale x="2" y="2"/>` | `<scale x="300" y="300"/>`

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)