### PR TITLE
[Bug fix] Fix comment and resolution of output in differentiable rendering example

### DIFF
--- a/docs/examples/10_inverse_rendering/invert_bunny.py
+++ b/docs/examples/10_inverse_rendering/invert_bunny.py
@@ -1,4 +1,4 @@
-# Simple inverse rendering example: render a cornell box reference image, then
+# Advanced inverse rendering example: render a bunny reference image,
 # then replace one of the scene parameters and try to recover it using
 # differentiable rendering and gradient-based optimization.
 
@@ -46,7 +46,7 @@ for it in range(iterations):
     image = render(scene, optimizer=opt, unbiased=True, spp=1)
     write_bitmap('out_%03i.png' % it, image, crop_size)
     write_bitmap('envmap_%03i.png' % it, params['my_envmap.data'],
-                 (param_res[1], param_res[0]))
+                 (param_res[0], param_res[1]))
 
     # Objective: MSE between 'image' and 'image_ref'
     ob_val = ek.hsum(ek.sqr(image - image_ref)) / len(image)

--- a/docs/examples/10_inverse_rendering/invert_cbox.py
+++ b/docs/examples/10_inverse_rendering/invert_cbox.py
@@ -1,4 +1,4 @@
-# Simple inverse rendering example: render a cornell box reference image, then
+# Simple inverse rendering example: render a cornell box reference image,
 # then replace one of the scene parameters and try to recover it using
 # differentiable rendering and gradient-based optimization.
 

--- a/docs/src/inverse_rendering/advanced.rst
+++ b/docs/src/inverse_rendering/advanced.rst
@@ -82,7 +82,7 @@ that we can now also write out the current environment image in each iteration.
         image = render(scene, optimizer=opt, unbiased=True, spp=1)
         write_bitmap('out_%03i.png' % it, image, crop_size)
         write_bitmap('envmap_%03i.png' % it, params['my_envmap.data'],
-                     (param_res[1], param_res[0]))
+                     (param_res[0], param_res[1]))
 
         # Objective: MSE between 'image' and 'image_ref'
         ob_val = ek.hsum(ek.sqr(image - image_ref)) / len(image)


### PR DESCRIPTION
*Please add the labels (e.g. bug, feature, ..) corresponding to this PR*

## Description

https://mitsuba2.readthedocs.io/en/latest/src/inverse_rendering/advanced.html

Example code shows learning and writing environment map. However, its result is different from the above link.

Before

![before](https://user-images.githubusercontent.com/11532321/102070345-57fe9d80-3e42-11eb-9ad1-e2fd67286b7a.png)

After

![after](https://user-images.githubusercontent.com/11532321/102070353-5a60f780-3e42-11eb-865f-853499d81ef7.png)


*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.*

Fixes # (issue)

## Checklist:

*Please make sure to complete this checklist before requesting a review.*

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)