### PR TITLE
add setpath.ps1 for windows powershell

### DIFF
--- a/setpath.ps1
+++ b/setpath.ps1
@@ -1,0 +1,10 @@
+
+# ***************************************************************
+# * This script adds Mitsuba to the current path on Windows.
+# * It assumes that Mitsuba is either compiled within the 
+# * source tree or within a subdirectory named 'build'.
+# ***************************************************************
+
+$env:MITSUBA_DIR=Get-Location
+$env:PATH=$env:PATH + ";" + $env:MITSUBA_DIR + "\dist;" + $env:MITSUBA_DIR + "\build\dist"
+$env:PYTHONPATH=$env:PYTHONPATH + ";" +$env:MITSUBA_DIR + "\dist\python;" + $env:MITSUBA_DIR + "\build\dist\python"


### PR DESCRIPTION
## Description

Added setpath.ps1 for windows powershell. Since executing setpath.bat inside powershell does not set any environment variables.

## Testing
This is what I get after running setpath.ps1 and checking the variables:
```
PS C:\Users\kopetri\mitsuba2> $env:PYTHONPATH
;C:\Users\kopetri\mitsuba2\dist\python;C:\Users\kopetri\mitsuba2\build\dist\python

PS C:\Users\kopetri\mitsuba2> $env:PATH
;C:\Users\kopetri\mitsuba2\dist;C:\Users\kopetri\mitsuba2\build\dist

PS C:\Users\kopetri\mitsuba2> $env:MITSUBA_DIR
;C:\Users\kopetri\mitsuba2
```

