### PR TITLE
Normalmap traverse

### DIFF
--- a/src/bsdfs/normalmap.cpp
+++ b/src/bsdfs/normalmap.cpp
@@ -156,6 +156,11 @@ public:
         return result;
     }
 
+    void traverse(TraversalCallback *callback) override {
+       callback->put_object("normalmap", m_normalmap.get());
+       callback->put_object("nested_bsdf", m_nested_bsdf.get());
+    }
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "NormalMap[" << std::endl


### PR DESCRIPTION
Improving the interface with python for `normalmap` and `emitter`.

First commit (cc4b6db) adds recursive `traverse` method for the `normalmap` plugin that enables to access the BSDF below the `normalmap` in the hierarchy. This enables to select the albedo of a diffuse BRDF for optimization purposes.

Second commit (ff221e4) exposes a method to change the `AnimatedTransform` of an `emitter`.