### PR TITLE
Blender refactoring

### DIFF
--- a/include/mitsuba/core/bitmap.h
+++ b/include/mitsuba/core/bitmap.h
@@ -182,17 +182,17 @@ public:
     // ======================================================================
 
     /**
-     * \brief Create a bitmap of the specified type and allocate
-     * the necessary amount of memory
+     * \brief Create a bitmap of the specified type and allocate the necessary
+     * amount of memory
      *
      * \param pixel_format
      *    Specifies the pixel format (e.g. RGBA or Luminance-only)
      *
      * \param component_format
-     *    Specifies how the per-pixel components are encoded
-     *    (e.g. unsigned 8 bit integers or 32-bit floating point values).
-     *    The component format struct_type_v<Float> will be translated to the
-     *    corresponding compile-time precision type (Float32 or Float64).
+     *    Specifies how the per-pixel components are encoded (e.g. unsigned 8
+     *    bit integers or 32-bit floating point values). The component format
+     *    struct_type_v<Float> will be translated to the corresponding
+     *    compile-time precision type (Float32 or Float64).
      *
      * \param size
      *    Specifies the horizontal and vertical bitmap size in pixels
@@ -200,6 +200,10 @@ public:
      * \param channel_count
      *    Channel count of the image. This parameter is only required when
      *    \c pixel_format = \ref PixelFormat::MultiChannel
+     *
+     * \param channel_names
+     *    Channel names of the image. This parameter is optional, and only used
+     *    when \c pixel_format = \ref PixelFormat::MultiChannel
      *
      * \param data
      *    External pointer to the image data. If set to \c nullptr, the
@@ -209,6 +213,7 @@ public:
            Struct::Type component_format,
            const Vector2u &size,
            size_t channel_count = 0,
+           const std::vector<std::string> &channel_names = {},
            uint8_t *data = nullptr);
 
     /**
@@ -585,7 +590,7 @@ public:
      virtual ~Bitmap();
 
      /// Rebuild the 'm_struct' field based on the pixel format etc.
-     void rebuild_struct(size_t channel_count = 0);
+     void rebuild_struct(size_t channel_count = 0, const std::vector<std::string> &channel_names = {});
 
      /// Read a file from a stream
      void read(Stream *stream, FileFormat format);

--- a/src/bsdfs/measured_polarized.cpp
+++ b/src/bsdfs/measured_polarized.cpp
@@ -271,7 +271,7 @@ public:
 
                 /* Invalid configurations such as transmission directions are encoded as NaNs.
                    Make sure these values don't end up in the interpolated value. */
-                ek::masked(value, ek::any(isnan(value(0,0)))) = 0.f;
+                ek::masked(value, ek::any(ek::isnan(value(0,0)))) = 0.f;
 
                 // Make sure intensity is non-negative
                 value(0,0) = ek::max(0.f, value(0,0));

--- a/src/films/hdrfilm.cpp
+++ b/src/films/hdrfilm.cpp
@@ -193,9 +193,9 @@ public:
         channels_sorted.push_back("G");
         channels_sorted.push_back("B");
         std::sort(channels_sorted.begin(), channels_sorted.end());
-        for (size_t i = 1; i < channels.size(); ++i) {
-            if (channels[i] == channels[i - 1])
-                Throw("Film::prepare(): duplicate channel name \"%s\"", channels[i]);
+        for (size_t i = 1; i < channels_sorted.size(); ++i) {
+            if (channels_sorted[i] == channels_sorted[i - 1])
+                Throw("Film::prepare(): duplicate channel name \"%s\"", channels_sorted[i]);
         }
 
         m_storage = new ImageBlock(m_crop_size, channels.size());

--- a/src/films/hdrfilm.cpp
+++ b/src/films/hdrfilm.cpp
@@ -256,7 +256,7 @@ public:
         ref<Bitmap> source = new Bitmap(m_channels.size() != 5 ? Bitmap::PixelFormat::MultiChannel
                                                                : Bitmap::PixelFormat::XYZAW,
                           struct_type_v<ScalarFloat>, m_storage->size(), m_storage->channel_count(),
-                          (uint8_t *) storage.data());
+                          m_channels, (uint8_t *) storage.data());
 
         if (raw)
             return source;
@@ -310,8 +310,6 @@ public:
                         dest_field.name = m_channels[i];
                         break;
                 }
-
-                source_field.name = m_channels[i];
             }
         }
 

--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -91,7 +91,7 @@ public:
 
             if (item[1] == "depth") {
                 m_aov_types.push_back(Type::Depth);
-                m_aov_names.push_back(item[0]);
+                m_aov_names.push_back(item[0] + ".T");
             } else if (item[1] == "position") {
                 m_aov_types.push_back(Type::Position);
                 m_aov_names.push_back(item[0] + ".X");

--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -170,7 +170,7 @@ public:
         for (size_t i = 0; i < m_aov_types.size(); ++i) {
             switch (m_aov_types[i]) {
                 case Type::Depth:
-                    *aovs++ = si.t;
+                    *aovs++ = ek::select(si.is_valid(), si.t, 0.f);
                     break;
 
                 case Type::Position:

--- a/src/libcore/python/bitmap.cpp
+++ b/src/libcore/python/bitmap.cpp
@@ -41,8 +41,8 @@ MTS_PY_EXPORT(Bitmap) {
         .value("Unpremultiply", Bitmap::AlphaTransform::Unpremultiply,
                 D(Bitmap, AlphaTransform, Unpremultiply));
 
-    bitmap.def(py::init<Bitmap::PixelFormat, Struct::Type, const Vector2u &, size_t>(),
-            "pixel_format"_a, "component_format"_a, "size"_a, "channel_count"_a = 0,
+    bitmap.def(py::init<Bitmap::PixelFormat, Struct::Type, const Vector2u &, size_t, std::vector<std::string>>(),
+            "pixel_format"_a, "component_format"_a, "size"_a, "channel_count"_a = 0, "channel_names"_a = std::vector<std::string>(),
             D(Bitmap, Bitmap))
 
         .def(py::init([](py::array obj, py::object pixel_format_) {

--- a/src/libcore/tests/test_write_xml.py
+++ b/src/libcore/tests/test_write_xml.py
@@ -410,6 +410,7 @@ def test11_xml_spectrum(variants_all_scalar):
     from mitsuba.python.xml import dict_to_xml
     from mitsuba.core.xml import load_dict, load_file
     from mitsuba.core import Thread
+    from re import escape
     fr = Thread.thread().file_resolver()
     mts_root = str(fr[len(fr)-1])
     filepath = os.path.join(mts_root, 'resources/data/scenes/dict11/dict.xml')
@@ -507,7 +508,7 @@ def test11_xml_spectrum(variants_all_scalar):
     with pytest.raises(ValueError) as e:
         dict_to_xml(d5, filepath)
     try:
-        e.match("File '%s' not found!" % os.path.abspath(d5['light']['intensity']['filename']))
+        e.match(escape(f"File '{os.path.abspath(d5['light']['intensity']['filename'])}' not found!"))
     except AssertionError as err:
         rmtree(os.path.split(filepath)[0])
         raise err

--- a/src/python/python/xml.py
+++ b/src/python/python/xml.py
@@ -26,7 +26,7 @@ class WriteXML:
         'height': 'resy'
     }
 
-    def __init__(self, path, subfolders, split_files=False):
+    def __init__(self, path, subfolders=None, split_files=False):
         from mitsuba import variant
         if not variant():
             mitsuba.set_variant('scalar_rgb')
@@ -48,7 +48,15 @@ class WriteXML:
         self.file_stack = []
         self.current_file = Files.MAIN
         self.directory = '' # scene foler
-        self.subfolders = subfolders
+        if subfolders is not None:
+            self.subfolders = subfolders
+        else:
+            self.subfolders = {
+                'texture': 'textures',
+                'emitter': 'textures',
+                'shape': 'meshes',
+                'spectrum': 'spectra'
+                }
         self.set_filename(path)
 
     def data_add(self, key, value, file=Files.MAIN):

--- a/src/python/python/xml.py
+++ b/src/python/python/xml.py
@@ -716,5 +716,9 @@ class WriteXML:
         return params
 
 def dict_to_xml(scene_dict, filename, split_files=False):
-    writer = WriteXML(filename, split_files)
-    writer.process(scene_dict)
+    writer = WriteXML(filename, split_files=split_files)
+    try:
+        writer.process(scene_dict)
+    except Exception as e:
+        writer.exit() # Close all files in case of a failure
+        raise e

--- a/src/python/python/xml.py
+++ b/src/python/python/xml.py
@@ -508,7 +508,7 @@ class WriteXML:
         if not os.path.isfile(filepath):
             raise ValueError("File '%s' not found!" % filepath)
         if abs_path in filepath: # The file is at the proper place already
-            return os.path.relpath(filepath, self.directory)
+            return f"{subfolders[tag]}/{os.path.basename(filepath)}"
         else: # We need to copy the file in the scene directory
             if filepath in self.copied_paths: # File was already copied, don't copy it again
                 return self.copied_paths[filepath]
@@ -523,7 +523,7 @@ class WriteXML:
                 self.copy_count[base_name] = 1
             target_path = os.path.join(abs_path, "%s%s" % (name, ext))
             copy2(filepath, target_path)
-            rel_path = os.path.relpath(target_path, self.directory)
+            rel_path = f"{subfolders[tag]}/{name}{ext}"
             self.copied_paths[filepath] = rel_path
             return rel_path
 

--- a/src/sensors/perspective.cpp
+++ b/src/sensors/perspective.cpp
@@ -281,7 +281,7 @@ public:
 
     void traverse(TraversalCallback *callback) override {
         Base::traverse(callback);
-        // TODO x_fov
+        callback->put_parameter("x_fov", m_x_fov);
     }
 
     void parameters_changed(const std::vector<std::string> &keys) override {

--- a/src/shapes/blender.cpp
+++ b/src/shapes/blender.cpp
@@ -323,7 +323,6 @@ public:
         }
 
         set_children();
-
     }
 
     MTS_DECLARE_CLASS()


### PR DESCRIPTION

## Description

This PR introduces some bug fixes to the blender exporter, as well as a reimplementation of the `Bitmap::split method`.

Calling `Bitmap::split` now splits into bitmaps according to the prefix, and not only the pixel format. To that end, I added the possibility to provide a list of channel names to the `Bitmap` constructor.

A unit test was added to check the new behavior.