### PR TITLE
Correct typos

### DIFF
--- a/docs/src/advanced_topics/custom_plugins.rst
+++ b/docs/src/advanced_topics/custom_plugins.rst
@@ -34,7 +34,7 @@ In this example, we will implement a simple diffuse BSDF in Python by extending
 the :code:`BSDF` base class. The code is very similar to the diffuse BSDF
 implemented in C++ (in :code:`src/bsdf/diffuse.cpp`).
 
-The BSDF class need to implement the following 3 methods: :code:`sample`,
+The BSDF class needs to implement the following 3 methods: :code:`sample`,
 :code:`eval` and :code:`pdf`:
 
 .. literalinclude:: ../../examples/04_diffuse_bsdf/diffuse_bsdf.py

--- a/docs/src/python_interface/parsing_xml.rst
+++ b/docs/src/python_interface/parsing_xml.rst
@@ -88,7 +88,7 @@ A more convinient way of constructing Mitsuba objects in Python is to use
 should follow a structure similar to the XML structure used for the Mitsuba scene description.
 
 The dictionary should always contain an entry ``"type"`` to specify the name of the plugin to
-be instanciated. Keys of the dictionary must be strings and will represent the name of the
+be instantiated. Keys of the dictionary must be strings and will represent the name of the
 properties. The type of the property will be deduced from the Python type for simple
 types (e.g. ``bool``, ``float``, ``int``, ``string``, ...). It is possible to provide another dictionary as
 the value of an entry. This can be used to create nested objects, as in the XML scene description.

--- a/src/integrators/aov.cpp
+++ b/src/integrators/aov.cpp
@@ -22,7 +22,7 @@ Arbitrary Output Variables integrator (:monosp:`aov`)
      respective output will be put into distinct images.
 
 
-This integrator returns one or more AOVs (Arbitraty Output Variables) describing the visible
+This integrator returns one or more AOVs (Arbitrary Output Variables) describing the visible
 surfaces.
 
 .. subfigstart::

--- a/src/libcore/python/xml_v.cpp
+++ b/src/libcore/python/xml_v.cpp
@@ -202,7 +202,7 @@ ref<Object> load_dict(const py::dict &dict, std::map<std::string, ref<Object>> &
             }
 
             // Nested dict with type == "ref" specify a reference to another
-            // object previously instanciated
+            // object previously instantiated
             if (type2 == "ref") {
                 if (is_scene)
                     Throw("Reference found at the scene level: %s", key);

--- a/src/shapes/instance.cpp
+++ b/src/shapes/instance.cpp
@@ -37,7 +37,7 @@ details on how to create instances, refer to the :ref:`shape-shapegroup` plugin.
         :width: 100%
         :align: center
 
-    The Stanford bunny loaded a single time and instanciated 1365 times (equivalent to 100 million
+    The Stanford bunny loaded a single time and instantiated 1365 times (equivalent to 100 million
     triangles)
 
 .. warning::


### PR DESCRIPTION

## Description

This PR corrects a typo, replacing "instanciated" with "instantiated" in several locations.

## Testing

I did not test after making these modifications, because I believe the risk of an issue is sufficiently low.

## Checklist:

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [na] My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave below
- [na] I have commented my code
- [x] I have made corresponding changes to the documentation
- [na] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)