### PR TITLE
[bug] Removed automatic clamping for unbounded spectrum

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ rst_prolog = r"""
 .. |string| replace:: :paramtype:`string`
 .. |bsdf| replace:: :paramtype:`bsdf`
 .. |point| replace:: :paramtype:`point`
+.. |color| replace:: :paramtype:`color`
 .. |vector| replace:: :paramtype:`vector`
 .. |transform| replace:: :paramtype:`transform`
 

--- a/docs/docs_api/conf.py
+++ b/docs/docs_api/conf.py
@@ -49,6 +49,7 @@ rst_prolog = r"""
 .. |string| replace:: :paramtype:`string`
 .. |bsdf| replace:: :paramtype:`bsdf`
 .. |point| replace:: :paramtype:`point`
+.. |color| replace:: :paramtype:`color`
 .. |transform| replace:: :paramtype:`transform`
 
 .. |enoki| replace:: :monosp:`enoki`
@@ -735,7 +736,7 @@ def generate_list_api_callback(app):
 def setup(app):
     # Texinfo
     app.connect("builder-inited", generate_list_api_callback)
-    app.add_stylesheet('theme_overrides.css')
+    app.add_css_file('theme_overrides.css')
 
     # Autodoc
     app.connect('autodoc-process-docstring', process_docstring_callback)

--- a/ext/rgb2spec/CMakeLists.txt
+++ b/ext/rgb2spec/CMakeLists.txt
@@ -44,12 +44,21 @@ if (TARGET tbb)
   )
 endif()
 
-add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srgb.coeff
-  DEPENDS rgb2spec_opt
-  COMMAND ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH=.:$ENV{LD_LIBRARY_PATH}
-  $<TARGET_FILE:rgb2spec_opt> 64 ${CMAKE_CURRENT_BINARY_DIR}/srgb.coeff
-)
+if (APPLE)
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srgb.coeff
+    DEPENDS rgb2spec_opt
+    COMMAND ${CMAKE_COMMAND} -E env DYLD_LIBRARY_PATH=.:$ENV{DYLD_LIBRARY_PATH}
+    $<TARGET_FILE:rgb2spec_opt> 64 ${CMAKE_CURRENT_BINARY_DIR}/srgb.coeff
+  )
+else ()
+  add_custom_command(
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srgb.coeff
+      DEPENDS rgb2spec_opt
+      COMMAND ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH=.:$ENV{LD_LIBRARY_PATH}
+      $<TARGET_FILE:rgb2spec_opt> 64 ${CMAKE_CURRENT_BINARY_DIR}/srgb.coeff
+    )
+endif ()
 
 add_custom_target(
   rgb2spec_opt_run

--- a/src/spectra/srgb.cpp
+++ b/src/spectra/srgb.cpp
@@ -12,6 +12,16 @@ NAMESPACE_BEGIN(mitsuba)
 sRGB spectrum (:monosp:`srgb`)
 ------------------------------
 
+.. pluginparameters::
+
+ * - color
+   - |color|
+   - RGB color value
+ * - unbounded
+   - |bool|
+   - Allows the color components to be outside the range [0, 1]
+     (Default: false)
+
 In spectral render modes, this smooth spectrum is the result of the
 *spectral upsampling* process :cite:`Jakob2019Spectral` used by the system.
 In RGB render modes, this spectrum represents a constant RGB value.

--- a/src/spectra/srgb.cpp
+++ b/src/spectra/srgb.cpp
@@ -27,7 +27,9 @@ public:
     SRGBReflectanceSpectrum(const Properties &props) : Texture(props) {
         ScalarColor3f color = props.color("color");
 
-        if (any(color < 0 || color > 1) && !props.bool_("unbounded", false))
+        m_unbounded = props.bool_("unbounded", false);
+
+        if (any(color < 0 || color > 1) && !m_unbounded)
             Throw("Invalid RGB reflectance value %s, must be in the range [0, 1]!", color);
 
         if constexpr (is_spectral_v<Spectrum>) {
@@ -61,8 +63,10 @@ public:
     }
 
     void parameters_changed(const std::vector<std::string> &/*keys*/) override {
-        if constexpr (!is_spectral_v<Spectrum>)
-            m_value = clamp(m_value, 0.f, 1.f);
+        if constexpr (!is_spectral_v<Spectrum>){
+            if (!m_unbounded)
+                m_value = clamp(m_value, 0.f, 1.f);
+        }
     }
 
     std::string to_string() const override {
@@ -82,6 +86,7 @@ protected:
     static constexpr size_t ChannelCount = is_monochromatic_v<Spectrum> ? 1 : 3;
 
     Color<Float, ChannelCount> m_value;
+    bool m_unbounded;
 };
 
 MTS_IMPLEMENT_CLASS_VARIANT(SRGBReflectanceSpectrum, Texture)


### PR DESCRIPTION
paramaters_changed no longer clamps RGB/monochromatic values if unbounded property was specified

## Description

When changing the unbounded RGB/monochromatic spectrum through parameters update in python, the values were clamped to [0,1]. This was obviously unwanted as it e.g. prevented from changing eta/k parameters of the conductor BSDF to realistic values.

I have added a member variable m_unbounded to the SRGBReflectanceSpectrum which is initialized based on the properties and when python parameter update invoke the parameters_changed, the clamping now occurs only if the spectrum is unbounded.

## Testing

*Please describe the tests that you added to verify your changes.*

## Checklist:

*Please make sure to complete this checklist before requesting a review.*

- [X] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [X] My changes generate no new warnings
- [ ] My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I cleaned the commit history and removed any "Merge" commits
- [X] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)