### PR TITLE
[Bug] Fix building rgb2spec on MAC

### DIFF
--- a/ext/rgb2spec/CMakeLists.txt
+++ b/ext/rgb2spec/CMakeLists.txt
@@ -44,12 +44,21 @@ if (TARGET tbb)
   )
 endif()
 
-add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srgb.coeff
-  DEPENDS rgb2spec_opt
-  COMMAND ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH=.:$ENV{LD_LIBRARY_PATH}
-  $<TARGET_FILE:rgb2spec_opt> 64 ${CMAKE_CURRENT_BINARY_DIR}/srgb.coeff
-)
+if (APPLE)
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srgb.coeff
+    DEPENDS rgb2spec_opt
+    COMMAND ${CMAKE_COMMAND} -E env DYLD_LIBRARY_PATH=.:$ENV{DYLD_LIBRARY_PATH}
+    $<TARGET_FILE:rgb2spec_opt> 64 ${CMAKE_CURRENT_BINARY_DIR}/srgb.coeff
+  )
+else ()
+  add_custom_command(
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/srgb.coeff
+      DEPENDS rgb2spec_opt
+      COMMAND ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH=.:$ENV{LD_LIBRARY_PATH}
+      $<TARGET_FILE:rgb2spec_opt> 64 ${CMAKE_CURRENT_BINARY_DIR}/srgb.coeff
+    )
+endif ()
 
 add_custom_target(
   rgb2spec_opt_run


### PR DESCRIPTION
[Bug]

## Description

MAC systems do not use LD_LIBRARY_PATH but DYLD_LIBRARY_PATH.
Since the linker ignored the LD_LIBRARY_PATH on MAC it was looking for the system installed TBB instead of the one built locally.

Fixes # (issue)

After introducing a specific branch for MAC I've successfully built Mitsuba on MAC OS 12.3.1

## Checklist:

- [X] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [X] My changes generate no new warnings
- [ ] My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I cleaned the commit history and removed any "Merge" commits
- [X] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)