### PR TITLE
fix toWorld -> to_world

### DIFF
--- a/docs/src/getting_started/file_format.rst
+++ b/docs/src/getting_started/file_format.rst
@@ -99,7 +99,7 @@ more complex example:
              (compact) binary representation -->
         <shape type="serialized">
             <string name="filename" value="lightsource.serialized"/>
-            <transform name="toWorld">
+            <transform name="to_world">
                 <translate x="5" y="-3" z="1"/>
             </transform>
 

--- a/src/libcore/tests/test_xml.py
+++ b/src/libcore/tests/test_xml.py
@@ -115,7 +115,7 @@ def test09_incorrect_nesting(variant_scalar_rgb):
     with pytest.raises(Exception) as e:
         xml.load_string("""<scene version="2.0.0">
                    <shape type="ply">
-                   <transform name="toWorld">
+                   <transform name="to_world">
                    <integer name="value" value="10"/>
                    </transform>
                    </shape></scene>""")


### PR DESCRIPTION
## Description

Documentation includes old key "toWorld" in places where it should read "to_world" intead.

## Testing

No dedicated testing completed.

## Checklist:

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)