### PR TITLE
When generating documents, specify the encoding as UTF-8 when reading…

### DIFF
--- a/docs/docs_api/conf.py
+++ b/docs/docs_api/conf.py
@@ -631,7 +631,7 @@ def write_rst_file_callback(app, exception):
         f.write('\n')
 
     # Write extracted RST to file
-    with open(extracted_rst_filename, 'w') as f:
+    with open(extracted_rst_filename, 'w', encoding='utf-8') as f:
         print('Extract API doc into: %s' % extracted_rst_filename)
         for l in extracted_rst:
             f.write(l)
@@ -640,7 +640,7 @@ def write_rst_file_callback(app, exception):
     for lib in api_doc_structure.keys():
         lib_structure = api_doc_structure[lib]
         lib_api_filename = join(docs_path, 'generated/%s_api.rst' % lib)
-        with open(lib_api_filename, 'w') as f:
+        with open(lib_api_filename, 'w', encoding='utf-8') as f:
             print('Generate %s API RST file: %s' % (lib, lib_api_filename))
             f.write('.. _sec-api-%s:\n\n' % lib)
             f.write('%s API Reference\n' % lib.title())
@@ -723,7 +723,7 @@ def generate_list_api_callback(app):
             f.write('.. auto%s:: %s\n\n' %
                     ('class' if isclass(obj) else 'function', full_name))
 
-    with open(list_api_filename, 'w') as f:
+    with open(list_api_filename, 'w', encoding='utf-8') as f:
         print('Generate API list file: %s' % list_api_filename)
         for lib in ['core', 'render', 'python']:
             module = importlib.import_module('mitsuba.%s' % lib)

--- a/docs/generate_plugin_doc.py
+++ b/docs/generate_plugin_doc.py
@@ -89,7 +89,7 @@ def find_order_id(filename, ordering):
         return 1000
 
 def extract(target, filename):
-    f = open(filename)
+    f = open(filename, encoding='utf-8')
     inheader = False
     for line in f.readlines():
         match = re.match(r'^/\*\*! ?(.*)$', line)
@@ -131,14 +131,14 @@ def process(path, target, ordering):
 
     for entry in ordering:
         extract(target, entry[1])
-
+    
 
 def process_src(target, src_subdir, section=None, ordering=None):
     if section is None:
         section = "section_" + src_subdir
 
     # Copy paste the contents of the appropriate section file
-    with open('src/plugin_reference/' + section + '.rst', 'r') as f:
+    with open('src/plugin_reference/' + section + '.rst', 'r', encoding='utf-8') as f:
         target.write(f.read())
     process('../src/{0}'.format(src_subdir), target, ordering)
 
@@ -146,7 +146,7 @@ def process_src(target, src_subdir, section=None, ordering=None):
 def generate(build_dir):
     original_wd = os.getcwd()
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
-    with open(os.path.join(build_dir, 'plugins.rst'), 'w') as f:
+    with open(os.path.join(build_dir, 'plugins.rst'), 'w', encoding='utf-8') as f:
         process_src(f, 'shapes', 'section_shape', SHAPE_ORDERING)
         process_src(f, 'bsdfs', 'section_bsdf', BSDF_ORDERING)
         # process_src(f, 'subsurface')


### PR DESCRIPTION
## Description

When I try to build a document by myself, because the default encoding of my computer is not UTF-8, the document building fails. Therefore, I explicitly specify the encoding as UTF-8 when codes use the `open` statement to read and write files


## Checklist:

*Please make sure to complete this checklist before requesting a review.*

- [x] My code follows the [style guidelines](https://mitsuba2.readthedocs.io/en/latest/src/developer_guide/intro.html#introduction) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `gpu_*` and `packet_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 2 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba2/blob/master/LICENSE)